### PR TITLE
Add Clerk auth middleware

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -35,6 +35,7 @@ from langflow.interface.components import get_and_cache_all_types_dict
 from langflow.interface.utils import setup_llm_caching
 from langflow.logging.logger import configure
 from langflow.middleware import ContentSizeLimitMiddleware
+from langflow.services.auth.clerk_utils import clerk_token_middleware
 from langflow.services.deps import (
     get_queue_service,
     get_settings_service,
@@ -275,6 +276,8 @@ def create_app():
         request.scope["query_string"] = urlencode(flattened, doseq=True).encode("utf-8")
 
         return await call_next(request)
+
+    app.middleware("http")(clerk_token_middleware)
 
     settings = get_settings_service().settings
     if prome_port_str := os.environ.get("LANGFLOW_PROMETHEUS_PORT"):

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -162,7 +162,8 @@ async def get_current_user_by_jwt(
 
     if isinstance(token, Coroutine):
         token = await token
- 
+
+    # ✅ Clerk auth path — use UUID from payload already set in middleware
     if settings_service.auth_settings.CLERK_AUTH_ENABLED:
         return await get_user_from_clerk_payload(token, db)
 
@@ -231,6 +232,7 @@ async def get_current_user_by_jwt(
         )
 
     return user
+
 
 async def get_current_user_for_websocket(
     websocket: WebSocket,


### PR DESCRIPTION
## Summary
- decode Clerk tokens for `/api/v1/users/` requests
- clean up the token context after each request
- revert auth utility logic to previous version

## Testing
- `uv run ruff format src/backend/base/langflow/services/auth/utils.py src/backend/base/langflow/services/auth/clerk_utils.py src/backend/base/langflow/main.py`
- `uv run ruff check src/backend/base/langflow/services/auth/clerk_utils.py src/backend/base/langflow/services/auth/utils.py src/backend/base/langflow/main.py` *(fails: 12 errors)*
- `make unit_tests` *(fails: 10 failed, 225 passed, 106 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab8f6c688326bef1e1ee72ede725