### PR TITLE
Add optional Clerk authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,7 @@ LANGFLOW_STORE_ENVIRONMENT_VARIABLES=
 # Value must finish with slash /
 #BACKEND_URL=http://localhost:7860/
 BACKEND_URL=
+
+# Optional Clerk authentication settings
+CLERK_AUTH_ENABLED=false
+CLERK_PUBLISHABLE_KEY=

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.4.2",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
+        "@clerk/clerk-react": "^5.32.4",
         "@headlessui/react": "^2.0.4",
         "@hookform/resolvers": "^3.6.0",
         "@million/lint": "^1.0.0-rc.26",
@@ -755,7 +756,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -763,6 +763,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.32.4.tgz",
+      "integrity": "sha512-+tGhLXkmf5XmuetT7oYPwASw3sa1bQcV25VAnb3Vn0k3DqbTcD2blAxTd3Ks98E0VbeACSR3oJkmF5TnzOquEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.10.2",
+        "@clerk/types": "^4.63.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.10.2.tgz",
+      "integrity": "sha512-4bp080EPX9Z/qLSdf9V22NNATC5GFjfEOtlfAOw2Xq24IAIxve3ePd92TcAsMHYThn3Pmwcj7upnvUB24IXKQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.63.0",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.63.0.tgz",
+      "integrity": "sha512-U3FTDzKx8uGve8gtaRv/QpfhEjK/dg9m9BuzIhYEowZ56jNimXDaXuijAcCZEeKwf+DDQmAPaNOinev6D2qtiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -9358,6 +9418,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/global-dirs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -10518,6 +10584,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -15579,6 +15654,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
@@ -15886,6 +15967,19 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "license": "MIT"
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -72,6 +72,7 @@
     "react-sortablejs": "^6.1.4",
     "react-syntax-highlighter": "^15.6.1",
     "reactflow": "^11.11.3",
+    "@clerk/clerk-react": "^5.32.4",
     "rehype-mathjax": "^4.0.3",
     "rehype-raw": "^6.1.1",
     "remark-gfm": "3.0.1",

--- a/src/frontend/src/clerk/clerk-auth-adapter.tsx
+++ b/src/frontend/src/clerk/clerk-auth-adapter.tsx
@@ -1,0 +1,35 @@
+import { useAuth } from "@clerk/clerk-react";
+import { useContext, useEffect } from "react";
+import { Cookies } from "react-cookie";
+import { AuthContext } from "@/contexts/authContext";
+import useAuthStore from "@/stores/authStore";
+import { LANGFLOW_API_TOKEN, LANGFLOW_ACCESS_TOKEN } from "@/constants/constants";
+import { api } from "@/controllers/API/api";
+
+export default function ClerkAuthAdapter() {
+  const { session, getToken } = useAuth();
+  const { login } = useContext(AuthContext);
+
+  useEffect(() => {
+    async function sync() {
+      const token = await getToken();
+      const cookies = new Cookies();
+
+      if (token) {
+        // use the same login helper used by the normal flow
+        login(token, "login");
+        // refreshToken not needed
+        const { data } = await api.get("/api/v1/users/whoami");
+        cookies.set(LANGFLOW_API_TOKEN, data.store_api_key, { path: "/" });
+      } else {
+        useAuthStore.getState().logout();
+        cookies.remove(LANGFLOW_API_TOKEN);
+        cookies.remove(LANGFLOW_ACCESS_TOKEN);
+      }
+    }
+
+    sync();
+  }, [session, getToken]);
+
+  return null;
+}

--- a/src/frontend/src/clerk/clerk-provider.tsx
+++ b/src/frontend/src/clerk/clerk-provider.tsx
@@ -1,0 +1,13 @@
+import { ClerkProvider } from "@clerk/clerk-react";
+import ContextWrapper from "@/contexts";
+import { CLERK_PUBLISHABLE_KEY } from "@/constants/constants";
+import ClerkAuthAdapter from "./clerk-auth-adapter";
+
+export default function ClerkAuthProvider({ children }) {
+  return (
+    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
+      <ClerkAuthAdapter />
+      <ContextWrapper>{children}</ContextWrapper>
+    </ClerkProvider>
+  );
+}

--- a/src/frontend/src/clerk/queries/use-clerk-logout.ts
+++ b/src/frontend/src/clerk/queries/use-clerk-logout.ts
@@ -1,0 +1,7 @@
+import { clerkClient } from "@clerk/clerk-react";
+import useAuthStore from "@/stores/authStore";
+
+export const useClerkLogout = () => async () => {
+  await clerkClient.signOut();
+  useAuthStore.getState().logout();
+};

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -6,7 +6,9 @@ import {
   GITHUB_URL,
   TWITTER_URL,
 } from "@/constants/constants";
+import { IS_CLERK_AUTH } from "@/constants/constants";
 import { useLogout } from "@/controllers/API/queries/auth";
+import { useClerkLogout } from "@/clerk/queries/use-clerk-logout";
 import { CustomProfileIcon } from "@/customization/components/custom-profile-icon";
 import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
@@ -31,6 +33,7 @@ export const AccountMenu = () => {
   const latestVersion = useDarkStore((state) => state.latestVersion);
   const navigate = useCustomNavigate();
   const { mutate: mutationLogout } = useLogout();
+  const clerkLogout = useClerkLogout();
 
   const { isAdmin, autoLogin } = useAuthStore((state) => ({
     isAdmin: state.isAdmin,
@@ -38,7 +41,11 @@ export const AccountMenu = () => {
   }));
 
   const handleLogout = () => {
-    mutationLogout();
+    if (IS_CLERK_AUTH) {
+      clerkLogout();
+    } else {
+      mutationLogout();
+    }
   };
 
   const isLatestVersion = version === latestVersion;

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -1026,9 +1026,15 @@ export const POLLING_MESSAGES = {
 
 export const BUILD_POLLING_INTERVAL = 25;
 
+export const IS_CLERK_AUTH =
+  String(process.env.CLERK_AUTH_ENABLED).toLowerCase() === "true";
+export const CLERK_PUBLISHABLE_KEY =
+  process.env.CLERK_PUBLISHABLE_KEY || "";
+
 export const IS_AUTO_LOGIN =
-  !process?.env?.LANGFLOW_AUTO_LOGIN ||
-  String(process?.env?.LANGFLOW_AUTO_LOGIN)?.toLowerCase() !== "false";
+  !IS_CLERK_AUTH &&
+  (!process?.env?.LANGFLOW_AUTO_LOGIN ||
+    String(process?.env?.LANGFLOW_AUTO_LOGIN)?.toLowerCase() !== "false");
 
 export const AUTO_LOGIN_RETRY_DELAY = 2000;
 export const AUTO_LOGIN_MAX_RETRY_DELAY = 60000;

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -10,10 +10,23 @@ import "./style/applies.css";
 
 // @ts-ignore
 import App from "./customization/custom-App";
+import { IS_CLERK_AUTH } from "./constants/constants";
+import ClerkAuthProvider from "./clerk/clerk-provider";
+import ContextWrapper from "./contexts";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
-root.render(<App />);
+root.render(
+  IS_CLERK_AUTH ? (
+    <ClerkAuthProvider>
+      <App />
+    </ClerkAuthProvider>
+  ) : (
+    <ContextWrapper>
+      <App />
+    </ContextWrapper>
+  ),
+);
 reportWebVitals();

--- a/src/frontend/src/pages/ClerkLoginPage/index.tsx
+++ b/src/frontend/src/pages/ClerkLoginPage/index.tsx
@@ -1,0 +1,4 @@
+import { SignIn } from "@clerk/clerk-react";
+export default function ClerkLoginPage() {
+  return <SignIn />;
+}

--- a/src/frontend/src/pages/ClerkSignUpPage/index.tsx
+++ b/src/frontend/src/pages/ClerkSignUpPage/index.tsx
@@ -1,0 +1,20 @@
+import { SignUp, useUser } from "@clerk/clerk-react";
+import { useAddUser } from "@/controllers/API/queries/auth";
+import { useEffect, useRef } from "react";
+
+export default function ClerkSignUpPage() {
+  const { isSignedIn, user } = useUser();
+  const { mutate: addUser } = useAddUser();
+  const created = useRef(false);
+
+  useEffect(() => {
+    if (!created.current && isSignedIn && user) {
+      const username = user.username || user.primaryEmailAddress?.emailAddress;
+      if (username) {
+        addUser({ username, password: "" }, { onSettled: () => { created.current = true; } });
+      }
+    }
+  }, [isSignedIn, user, addUser]);
+
+  return <SignUp />;
+}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -13,6 +13,7 @@ import ContextWrapper from "./contexts";
 import CustomDashboardWrapperPage from "./customization/components/custom-DashboardWrapperPage";
 import { CustomNavigate } from "./customization/components/custom-navigate";
 import { BASENAME } from "./customization/config-constants";
+import { IS_CLERK_AUTH } from "./constants/constants";
 import {
   ENABLE_CUSTOM_PARAM,
   ENABLE_FILE_MANAGEMENT,
@@ -24,6 +25,8 @@ import { AppInitPage } from "./pages/AppInitPage";
 import { AppWrapperPage } from "./pages/AppWrapperPage";
 import FlowPage from "./pages/FlowPage";
 import LoginPage from "./pages/LoginPage";
+import ClerkLoginPage from "./pages/ClerkLoginPage";
+import ClerkSignUpPage from "./pages/ClerkSignUpPage";
 import FilesPage from "./pages/MainPage/pages/filesPage";
 import HomePage from "./pages/MainPage/pages/homePage";
 import CollectionPage from "./pages/MainPage/pages/main-page";
@@ -41,7 +44,10 @@ const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 
 const PlaygroundPage = lazy(() => import("./pages/Playground"));
 
-const SignUp = lazy(() => import("./pages/SignUpPage"));
+const SignUpPage = lazy(() => import("./pages/SignUpPage"));
+
+const LoginRoute = IS_CLERK_AUTH ? ClerkLoginPage : LoginPage;
+const SignUpRoute = IS_CLERK_AUTH ? ClerkSignUpPage : SignUpPage;
 
 const router = createBrowserRouter(
   createRoutesFromElements([
@@ -163,7 +169,7 @@ const router = createBrowserRouter(
             path="login"
             element={
               <ProtectedLoginRoute>
-                <LoginPage />
+                <LoginRoute />
               </ProtectedLoginRoute>
             }
           />
@@ -171,7 +177,7 @@ const router = createBrowserRouter(
             path="signup"
             element={
               <ProtectedLoginRoute>
-                <SignUp />
+                <SignUpRoute />
               </ProtectedLoginRoute>
             }
           />


### PR DESCRIPTION
## Summary
- add Clerk environment flags and constants
- introduce Clerk provider and auth adapter
- support Clerk login/signup pages and routing
- integrate Clerk logout handling
- wrap app with Clerk provider when enabled

## Testing
- `npm run type-check` *(fails: Found 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc9da24c8326b232b8d936ce593b