### PR TITLE
Add Clerk signout to logout mutation

### DIFF
--- a/src/frontend/src/clerk/clerk-logout.ts
+++ b/src/frontend/src/clerk/clerk-logout.ts
@@ -1,0 +1,29 @@
+import { IS_CLERK_AUTH } from "@/constants/clerk";
+import { useLogout as useLogoutMutation } from "@/controllers/API/queries/auth";
+import { useClerk } from "@clerk/clerk-react";
+
+export function useLogout(options?: Parameters<typeof useLogoutMutation>[0]) {
+  const { mutate, mutateAsync, ...rest } = useLogoutMutation(options);
+  const { signOut } = IS_CLERK_AUTH ? useClerk() : { signOut: async () => {} };
+
+  const clerkSignOut = async () => {
+    if (IS_CLERK_AUTH) {
+      try {
+        await signOut();
+      } catch (err) {
+        console.error("Clerk signOut failed:", err);
+      }
+    }
+  };
+
+  const wrappedMutate: typeof mutate = (...args) => {
+    clerkSignOut().finally(() => mutate(...args));
+  };
+
+  const wrappedMutateAsync: typeof mutateAsync = async (...args) => {
+    await clerkSignOut();
+    return mutateAsync(...args);
+  };
+
+  return { mutate: wrappedMutate, mutateAsync: wrappedMutateAsync, clerkSignOut, ...rest };
+}

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -1,3 +1,4 @@
+import { useLogout } from "@/clerk/clerk-logout";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import {
   DATASTAX_DOCS_URL,
@@ -6,7 +7,6 @@ import {
   GITHUB_URL,
   TWITTER_URL,
 } from "@/constants/constants";
-import { useLogout } from "@/controllers/API/queries/auth";
 import { CustomProfileIcon } from "@/customization/components/custom-profile-icon";
 import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";


### PR DESCRIPTION
## Summary
- wrap logout mutation so Clerk signOut runs first
- keep account menu logic the same, only change import path

## Testing
- `npm run format` *(fails: cannot find prettier plugin)*
- `npm run type-check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68695f8202f48326aa549e29ddee56ba