### PR TITLE
Fix context hierarchy so Clerk login uses real handler

### DIFF
--- a/src/frontend/src/clerk/auth.tsx
+++ b/src/frontend/src/clerk/auth.tsx
@@ -90,7 +90,6 @@ export function ClerkAuthAdapter() {
 export function ClerkAuthProvider({ children }: { children: ReactNode }) {
   return (
     <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
-      <ClerkAuthAdapter />
       {children}
     </ClerkProvider>
   );

--- a/src/frontend/src/contexts/index.tsx
+++ b/src/frontend/src/contexts/index.tsx
@@ -6,6 +6,7 @@ import { ReactNode } from "react";
 import { TooltipProvider } from "../components/ui/tooltip";
 import { ApiInterceptor } from "../controllers/API/api";
 import { AuthProvider } from "./authContext";
+import { IS_CLERK_AUTH, ClerkAuthAdapter } from "@/clerk/auth";
 
 export default function ContextWrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ export default function ContextWrapper({ children }: { children: ReactNode }) {
         <GradientWrapper>
           <QueryClientProvider client={queryClient}>
             <AuthProvider>
+              {IS_CLERK_AUTH && <ClerkAuthAdapter />}
               <TooltipProvider skipDelayDuration={0}>
                 <ReactFlowProvider>
                   <ApiInterceptor />


### PR DESCRIPTION
## Summary
- ensure AuthProvider wraps ClerkAuthAdapter so login uses real AuthContext
- remove unused ClerkAuthAdapter from ClerkAuthProvider

## Testing
- `npm run check-format` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `npm run type-check` *(fails: 1702 errors due to missing packages and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6875d4c8131483269e78feb0b3d233a7