### PR TITLE
Add Clerk auth settings fields

### DIFF
--- a/src/backend/base/langflow/services/settings/auth.py
+++ b/src/backend/base/langflow/services/settings/auth.py
@@ -50,6 +50,9 @@ class AuthSettings(BaseSettings):
     COOKIE_DOMAIN: str | None = None
     """The domain attribute of the cookies. If None, the domain is not set."""
 
+    CLERK_AUTH_ENABLED: bool = False
+    CLERK_PUBLISHABLE_KEY: str | None = None
+
     pwd_context: CryptContext = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
     model_config = SettingsConfigDict(validate_assignment=True, extra="ignore", env_prefix="LANGFLOW_")


### PR DESCRIPTION
## Summary
- extend `AuthSettings` with Clerk auth options

## Testing
- `pre-commit run --files src/backend/base/langflow/services/settings/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d058b95083269b53ff63d710dc33