### PR TITLE
Add organisation database creation endpoint

### DIFF
--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -12,6 +12,7 @@ from langflow.api.v1 import (
     mcp_projects_router,
     mcp_router,
     monitor_router,
+    organisation_router,
     projects_router,
     starter_projects_router,
     store_router,
@@ -47,6 +48,7 @@ router_v1.include_router(files_router)
 router_v1.include_router(monitor_router)
 router_v1.include_router(folders_router)
 router_v1.include_router(projects_router)
+router_v1.include_router(organisation_router)
 router_v1.include_router(starter_projects_router)
 router_v1.include_router(voice_mode_router)
 router_v1.include_router(mcp_router)

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -1,5 +1,6 @@
 from langflow.api.v1.api_key import router as api_key_router
 from langflow.api.v1.chat import router as chat_router
+from langflow.api.v1.create_organisation import router as organisation_router
 from langflow.api.v1.endpoints import router as endpoints_router
 from langflow.api.v1.files import router as files_router
 from langflow.api.v1.flows import router as flows_router
@@ -27,6 +28,7 @@ __all__ = [
     "mcp_projects_router",
     "mcp_router",
     "monitor_router",
+    "organisation_router",
     "projects_router",
     "starter_projects_router",
     "store_router",

--- a/src/backend/base/langflow/api/v1/create_organisation.py
+++ b/src/backend/base/langflow/api/v1/create_organisation.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+
+from langflow.services.database.organisation import OrganisationService
+
+router = APIRouter(tags=["Organisation"])
+
+
+@router.post("/create_organisation")
+async def create_organisation():
+    """Create a new organisation database."""
+    service = OrganisationService()
+    try:
+        await service.create_database_and_tables_other_initializations_with_org()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return {"detail": "Organisation database created"}

--- a/src/backend/base/langflow/services/database/organisation.py
+++ b/src/backend/base/langflow/services/database/organisation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+
+from langflow.logging.logger import logger
+from langflow.services.auth.clerk_utils import auth_header_ctx
+from langflow.services.deps import get_db_service, get_settings_service
+from langflow.services.settings.service import SettingsService
+from langflow.services.utils import setup_superuser
+
+from .service import DatabaseService
+
+
+def _build_database_url_for_org(base_url: str, org_id: str) -> str:
+    """Return a database URL for the given organisation."""
+    if base_url.startswith("sqlite"):
+        if "/" in base_url:
+            prefix = base_url.rsplit("/", 1)[0]
+            new_url = f"{prefix}/{org_id}.db"
+        else:
+            new_url = f"{org_id}.db"
+    else:
+        match = re.match(r"^(?P<prefix>.+/)(?P<dbname>[^/?]+)(?P<suffix>.*)$", base_url)
+        if match:
+            new_url = f"{match.group('prefix')}{org_id}{match.group('suffix')}"
+        else:
+            logger.warning("Could not construct organisation DB url; using base url")
+            new_url = base_url
+    logger.debug(f"Derived organisation database URL: {new_url}")
+    return new_url
+
+
+class OrganisationService:
+    async def create_database_and_tables_other_initializations_with_org(self) -> None:
+        """Create and initialise a database for the organisation from auth context."""
+        payload: dict | None = auth_header_ctx.get()
+        if not payload:
+            msg = "Missing Clerk payload"
+            raise RuntimeError(msg)
+        org_id = payload.get("org_id")
+        if not org_id:
+            msg = "Missing organisation id"
+            raise RuntimeError(msg)
+
+        db_service = get_db_service()
+        base_url = db_service.database_url
+        new_url = _build_database_url_for_org(base_url, org_id)
+
+        settings_service = get_settings_service()
+        new_settings = settings_service.settings.model_copy()
+        new_settings.database_url = new_url
+        new_settings_service = SettingsService(new_settings, settings_service.auth_settings)
+
+        new_db_service = DatabaseService(new_settings_service)
+        if new_db_service.settings_service.settings.database_connection_retry:
+            await new_db_service.create_db_and_tables_with_retry()
+        else:
+            await new_db_service.create_db_and_tables()
+
+        await new_db_service.check_schema_health()
+        await new_db_service.run_migrations()
+
+        async with new_db_service.with_session() as session:
+            await setup_superuser(new_settings_service, session)
+
+        await new_db_service.teardown()


### PR DESCRIPTION
## Summary
- expose `/api/v1/create_organisation` without dependencies and delegate to `OrganisationService`
- compute organisation DB URLs using `get_db_service` and project logger
- restore `DatabaseService` to its original implementation

## Testing
- `pre-commit run --files src/backend/base/langflow/api/v1/create_organisation.py src/backend/base/langflow/services/database/organisation.py src/backend/base/langflow/services/database/service.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0ab8d57883268693226a475cc971