### PR TITLE
Refactor organisation router and service

### DIFF
--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -12,6 +12,7 @@ from langflow.api.v1 import (
     mcp_projects_router,
     mcp_router,
     monitor_router,
+    organisation_router,
     projects_router,
     starter_projects_router,
     store_router,
@@ -47,6 +48,7 @@ router_v1.include_router(files_router)
 router_v1.include_router(monitor_router)
 router_v1.include_router(folders_router)
 router_v1.include_router(projects_router)
+router_v1.include_router(organisation_router)
 router_v1.include_router(starter_projects_router)
 router_v1.include_router(voice_mode_router)
 router_v1.include_router(mcp_router)

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -8,6 +8,7 @@ from langflow.api.v1.login import router as login_router
 from langflow.api.v1.mcp import router as mcp_router
 from langflow.api.v1.mcp_projects import router as mcp_projects_router
 from langflow.api.v1.monitor import router as monitor_router
+from langflow.api.v1.organisation_router import router as organisation_router
 from langflow.api.v1.projects import router as projects_router
 from langflow.api.v1.starter_projects import router as starter_projects_router
 from langflow.api.v1.store import router as store_router
@@ -27,6 +28,7 @@ __all__ = [
     "mcp_projects_router",
     "mcp_router",
     "monitor_router",
+    "organisation_router",
     "projects_router",
     "starter_projects_router",
     "store_router",

--- a/src/backend/base/langflow/api/v1/organisation_router.py
+++ b/src/backend/base/langflow/api/v1/organisation_router.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+
+from langflow.services.database.organisation import OrganizationService
+
+router = APIRouter(tags=["Organisation"])
+
+
+@router.post("/create_organisation")
+async def create_organisation():
+    """Create a new organisation database."""
+    service = OrganizationService()
+    try:
+        await service.create_database_and_tables_other_initializations_with_org()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return {"detail": "Organisation database created"}

--- a/src/backend/base/langflow/services/database/organisation.py
+++ b/src/backend/base/langflow/services/database/organisation.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from pathlib import Path
+
+import anyio
+import sqlalchemy as sa
+from sqlmodel import SQLModel
+
+from langflow.logging.logger import logger
+from langflow.services.auth.clerk_utils import auth_header_ctx
+from langflow.services.database.service import DatabaseService
+from langflow.services.deps import get_db_service, get_settings_service
+from langflow.services.settings.service import SettingsService
+from langflow.services.utils import setup_superuser
+
+
+class OrganizationService:
+    _MAX_CACHE_SIZE = 128
+    _known_orgs: OrderedDict[str, None] = OrderedDict()
+
+    @classmethod
+    def _remember_org(cls, org_id: str) -> None:
+        cls._known_orgs.pop(org_id, None)
+        cls._known_orgs[org_id] = None
+        if len(cls._known_orgs) > cls._MAX_CACHE_SIZE:
+            cls._known_orgs.popitem(last=False)
+
+    @staticmethod
+    def _build_database_url_for_org(base_url: str, org_id: str) -> str:
+        """Return a database URL for the given organisation."""
+        if base_url.startswith("sqlite"):
+            if "/" in base_url:
+                prefix = base_url.rsplit("/", 1)[0]
+                new_url = f"{prefix}/{org_id}.db"
+            else:
+                new_url = f"{org_id}.db"
+        else:
+            match = re.match(
+                r"^(?P<prefix>.+/)(?P<dbname>[^/?]+)(?P<suffix>.*)$",
+                base_url,
+            )
+            if match:
+                new_url = f"{match.group('prefix')}{org_id}{match.group('suffix')}"
+            else:
+                logger.warning("Could not construct organisation DB url; using base url")
+                new_url = base_url
+        logger.debug(f"Derived organisation database URL: {new_url}")
+        return new_url
+
+    async def create_database_and_tables_other_initializations_with_org(self) -> None:
+        """Create and initialise a database for the organisation from auth context."""
+        payload: dict | None = auth_header_ctx.get()
+        if not payload:
+            msg = "Missing Clerk payload"
+            raise RuntimeError(msg)
+        org_id = payload.get("org_id")
+        if not org_id:
+            msg = "Missing organisation id"
+            raise RuntimeError(msg)
+
+        if org_id in self._known_orgs:
+            logger.debug("Organisation database already initialised (cached)")
+            self._remember_org(org_id)
+            return
+
+        db_service = get_db_service()
+        base_url = db_service.database_url
+        new_url = self._build_database_url_for_org(base_url, org_id)
+
+        settings_service = get_settings_service()
+        new_settings = settings_service.settings.model_copy()
+        new_settings.database_url = new_url
+        new_settings_service = SettingsService(new_settings, settings_service.auth_settings)
+
+        new_db_service = DatabaseService(new_settings_service)
+        try:
+            if await self._organisation_db_exists(new_db_service):
+                logger.debug("Organisation database already initialised")
+                self._remember_org(org_id)
+                return
+            if new_db_service.settings_service.settings.database_connection_retry:
+                await new_db_service.create_db_and_tables_with_retry()
+            else:
+                await new_db_service.create_db_and_tables()
+
+            await new_db_service.check_schema_health()
+            await new_db_service.run_migrations()
+
+            async with new_db_service.with_session() as session:
+                await setup_superuser(new_settings_service, session)
+            self._remember_org(org_id)
+        except Exception as exc:
+            logger.exception("Failed to initialise organisation database")
+            await self._cleanup_failed_initialization(new_db_service, new_url)
+            msg = "Failed to initialise organisation database"
+            raise RuntimeError(msg) from exc
+        finally:
+            await new_db_service.teardown()
+
+    @staticmethod
+    async def _cleanup_failed_initialization(db_service: DatabaseService, database_url: str) -> None:
+        """Attempt to clean up any artefacts from a failed organisation setup."""
+        try:
+            async with db_service.with_session() as session, session.bind.connect() as conn:
+                await conn.run_sync(SQLModel.metadata.drop_all)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error dropping organisation tables during cleanup")
+
+        if database_url.startswith("sqlite"):
+            try:
+                db_path = Path(database_url.split("///", 1)[1])
+            except IndexError:
+                logger.warning("Could not parse database path from url %s", database_url)
+                return
+            try:
+                await anyio.Path(db_path).unlink(missing_ok=True)
+            except Exception:  # noqa: BLE001
+                logger.exception("Error removing database file %s during cleanup", db_path)
+
+    @staticmethod
+    async def _organisation_db_exists(db_service: DatabaseService) -> bool:
+        """Return True if the organisation database already has required tables."""
+        try:
+            async with db_service.with_session() as session, session.bind.connect() as conn:
+                inspector = sa.inspect(conn)
+                required_tables = [
+                    "flow",
+                    "user",
+                    "apikey",
+                    "folder",
+                    "message",
+                    "variable",
+                    "transaction",
+                    "vertex_build",
+                ]
+                table_names = inspector.get_table_names()
+                return all(table in table_names for table in required_tables)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error checking organisation database existence")
+            return False


### PR DESCRIPTION
## Summary
- add organisation router for creating org databases
- move org database URL helper into OrganizationService
- expose new router in API
- rollback organisation database setup if initialization fails
- skip organisation initialization when database already exists
- cache known organisation databases to avoid redundant checks
- refresh cache entry on repeated organization initializations
- import DatabaseService from langflow package
- remove organisation service unit test

## Testing
- `uv run pre-commit run --files src/backend/base/langflow/services/database/organisation.py`


------
https://chatgpt.com/codex/tasks/task_e_688dcfa7e050832685a47b41b2bbbab3