### PR TITLE
Refactor Clerk auth handling

### DIFF
--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -31,7 +31,7 @@ async def add_user(
     """Add a new user to the database."""
     new_user = User.model_validate(user, from_attributes=True)
     try:
-        await process_new_user_with_clerk(user, new_user)
+        await process_new_user_with_clerk(new_user)
         new_user.password = get_password_hash(user.password)
         new_user.is_active = get_settings_service().auth_settings.NEW_USER_IS_ACTIVE
         session.add(new_user)

--- a/src/backend/base/langflow/services/auth/clerk_utils.py
+++ b/src/backend/base/langflow/services/auth/clerk_utils.py
@@ -11,7 +11,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.status import HTTP_401_UNAUTHORIZED
 
 from langflow.logging.logger import logger
-from langflow.services.database.models.user import User, UserCreate
+from langflow.services.database.models.user import User
 from langflow.services.database.models.user.crud import get_user_by_id
 from langflow.services.deps import get_settings_service
 
@@ -19,9 +19,6 @@ from langflow.services.deps import get_settings_service
 auth_header_ctx: ContextVar[dict | None] = ContextVar("auth_header_ctx", default=None)
 
 _jwks_cache: dict[str, dict[str, Any]] = {}
-
-# APIs that require Clerk token decoding in middleware
-PROTECTED_PATHS = ["/api/v1/users/", "/api/v1/login", "/api/v1/create_organisation"]
 
 
 async def _get_jwks(issuer: str) -> dict[str, Any]:
@@ -78,48 +75,37 @@ async def verify_clerk_token(token: str) -> dict[str, Any]:
     return payload
 
 
-async def process_new_user_with_clerk(_user: UserCreate, new_user: User):
-    settings = get_settings_service().auth_settings
-    # ✅ If Clerk is enabled, pull UUID from enriched auth_header_ctx payload
-    if settings.CLERK_AUTH_ENABLED:
-        payload = auth_header_ctx.get()
-        if not payload:
-            raise HTTPException(status_code=401, detail="Missing Clerk payload")
-        clerk_uuid = payload.get("uuid")
-        if not clerk_uuid:
-            raise HTTPException(status_code=401, detail="Missing Clerk UUID")
-        new_user.id = UUID(clerk_uuid)
-        logger.info(f"[process_new_user_with_clerk] Assigned Clerk UUID {new_user.id} to new user object")
-
-
-async def get_user_from_clerk_payload(token: str, db: AsyncSession) -> User:
-    """Retrieve the current user using the payload from ``verify_clerk_token``."""
+def get_user_id_from_clerk_payload() -> UUID:
+    """Extract the Clerk user UUID from the request context."""
+    payload = auth_header_ctx.get()
+    if not payload:
+        raise HTTPException(status_code=401, detail="Missing Clerk payload")
+    clerk_uuid = payload.get("uuid")
+    if not clerk_uuid:
+        raise HTTPException(status_code=401, detail="Missing Clerk UUID")
     try:
-        payload = await verify_clerk_token(token)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication failed",
-            headers={"WWW-Authenticate": "Bearer"},
-        ) from exc
-
-    uuid_str = payload.get("uuid")
-    logger.info(f"uuid_str: {uuid_str}")
-    if not uuid_str:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing Clerk UUID",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    try:
-        user_id = UUID(uuid_str)
+        return UUID(clerk_uuid)
     except ValueError as err:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=401,
             detail="Invalid Clerk UUID format",
             headers={"WWW-Authenticate": "Bearer"},
         ) from err
+
+
+async def process_new_user_with_clerk(new_user: User):
+    settings = get_settings_service().auth_settings
+    # ✅ If Clerk is enabled, pull UUID from enriched auth_header_ctx payload
+    if settings.CLERK_AUTH_ENABLED:
+        user_id = get_user_id_from_clerk_payload()
+        new_user.id = user_id
+        logger.info(f"[process_new_user_with_clerk] Assigned Clerk UUID {new_user.id} to new user object")
+
+
+async def get_user_from_clerk_payload(db: AsyncSession) -> User:
+    """Retrieve the current user using the payload stored in the request context."""
+    user_id = get_user_id_from_clerk_payload()
+    logger.debug(f"uuid_str: {user_id}")
 
     user = await get_user_by_id(db, user_id)
     logger.info(f"Retrieved user: {user}")
@@ -143,33 +129,30 @@ async def get_user_from_clerk_payload(token: str, db: AsyncSession) -> User:
 
 
 async def clerk_token_middleware(request: Request, call_next):
-    """Middleware to decode Clerk token for specific paths."""
+    """Middleware to decode Clerk token when present."""
     settings = get_settings_service()
+    if not settings.auth_settings.CLERK_AUTH_ENABLED:
+        return await call_next(request)
+
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return await call_next(request)
 
     ctx_token: Token | None = None
-    if settings.auth_settings.CLERK_AUTH_ENABLED and request.url.path in PROTECTED_PATHS:
-        auth_header = request.headers.get("Authorization")
-
-        if not auth_header or not auth_header.startswith("Bearer "):
-            logger.warning("Missing or malformed Authorization header for Clerk protected route.")
-            return JSONResponse(
-                status_code=HTTP_401_UNAUTHORIZED,
-                content={"detail": "Authorization header with valid Bearer token required"},
-            )
-
-        if auth_header and auth_header.startswith("Bearer "):
-            token = auth_header[len("Bearer ") :]
-            try:
-                payload = await verify_clerk_token(token)
-                ctx_token = auth_header_ctx.set(payload)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(f"Failed to verify Clerk token: {exc}")
-                return JSONResponse(status_code=HTTP_401_UNAUTHORIZED, content={"detail": "Invalid Clerk token"})
-
+    token = auth_header[len("Bearer ") :]
     try:
-        return await call_next(request)
+        payload = await verify_clerk_token(token)
+        ctx_token = auth_header_ctx.set(payload)
+        response = await call_next(request)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"Failed to verify Clerk token: {exc}")
+        return JSONResponse(
+            status_code=HTTP_401_UNAUTHORIZED,
+            content={"detail": "Invalid Clerk token"},
+        )
     finally:
         if ctx_token is not None:
             auth_header_ctx.reset(ctx_token)
         else:
             auth_header_ctx.set(None)
+    return response

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -164,7 +164,7 @@ async def get_current_user_by_jwt(
         token = await token
 
     if settings_service.auth_settings.CLERK_AUTH_ENABLED:
-        return await get_user_from_clerk_payload(token, db)
+        return await get_user_from_clerk_payload(db)
 
     secret_key = settings_service.auth_settings.SECRET_KEY.get_secret_value()
     if secret_key is None:


### PR DESCRIPTION
## Summary
- derive Clerk UUID from request context
- use context-based ID helper when creating and retrieving users
- streamline Clerk middleware to verify token only when present

## Testing
- `pre-commit run --files src/backend/base/langflow/services/auth/clerk_utils.py src/backend/base/langflow/services/auth/utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'blockbuster')*

------
https://chatgpt.com/codex/tasks/task_e_688e0bb5f79083269099d7f490c0c6e3