### PR TITLE
feat: add per-org database service cache

### DIFF
--- a/src/backend/base/langflow/api/v1/organisation_router.py
+++ b/src/backend/base/langflow/api/v1/organisation_router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 
 from langflow.services.database.organisation import OrganizationService
+from langflow.services.deps import get_settings_service
 
 router = APIRouter(tags=["Organisation"])
 
@@ -8,6 +9,10 @@ router = APIRouter(tags=["Organisation"])
 @router.post("/create_organisation")
 async def create_organisation():
     """Create a new organisation database."""
+    settings_service = get_settings_service()
+    if not settings_service.auth_settings.CLERK_AUTH_ENABLED:
+        raise HTTPException(status_code=404, detail="Not found")
+
     service = OrganizationService()
     try:
         await service.create_database_and_tables_other_initializations_with_org()

--- a/src/backend/base/langflow/services/deps.py
+++ b/src/backend/base/langflow/services/deps.py
@@ -137,6 +137,11 @@ def get_db_service() -> DatabaseService:
         The DatabaseService instance.
 
     """
+    from langflow.services.database.organisation import OrganizationService
+
+    if get_settings_service().auth_settings.CLERK_AUTH_ENABLED:
+        return OrganizationService.get_db_service_for_request()
+
     from langflow.services.database.factory import DatabaseServiceFactory
 
     return get_service(ServiceType.DATABASE_SERVICE, DatabaseServiceFactory())


### PR DESCRIPTION
## Summary
- cache `DatabaseService` instances per organization
- route `get_db_service` through `OrganizationService` only when Clerk auth is enabled, otherwise use the standard service manager
- ensure org-specific databases reuse engines across requests
- fall back to the global `DatabaseService` when Clerk auth is disabled
- clear failed per-org services from the cache so subsequent requests can reinitialize

## Testing
- `pre-commit run --files src/backend/base/langflow/services/database/organisation.py src/backend/base/langflow/services/deps.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'langflow.components')*


------
https://chatgpt.com/codex/tasks/task_e_688e492de3d48326bae9e6a2ef8ef1e0