### PR TITLE
feat: allow bypassing org db service at startup

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -472,7 +472,7 @@ def superuser(
 ) -> None:
     """Create a superuser."""
     configure(log_level=log_level)
-    db_service = get_db_service()
+    db_service = get_db_service(use_organisation=False)
 
     async def _create_superuser():
         await initialize_services()
@@ -540,7 +540,7 @@ def copy_db() -> None:
 
 async def _migration(*, test: bool, fix: bool) -> None:
     await initialize_services(fix_migration=fix)
-    db_service = get_db_service()
+    db_service = get_db_service(use_organisation=False)
     if not test:
         await db_service.run_migrations()
     results = await db_service.run_migrations_test()

--- a/src/backend/base/langflow/services/database/utils.py
+++ b/src/backend/base/langflow/services/database/utils.py
@@ -17,7 +17,8 @@ async def initialize_database(*, fix_migration: bool = False) -> None:
     logger.debug("Initializing database")
     from langflow.services.deps import get_db_service
 
-    database_service: DatabaseService = get_db_service()
+    # During initialization we always want the base database service
+    database_service: DatabaseService = get_db_service(use_organisation=False)
     try:
         if database_service.settings_service.settings.database_connection_retry:
             await database_service.create_db_and_tables_with_retry()

--- a/src/backend/base/langflow/services/deps.py
+++ b/src/backend/base/langflow/services/deps.py
@@ -130,7 +130,7 @@ def get_settings_service() -> SettingsService:
     return get_service(ServiceType.SETTINGS_SERVICE, SettingsServiceFactory())
 
 
-def get_db_service() -> DatabaseService:
+def get_db_service(*, use_organisation: bool = True) -> DatabaseService:
     """Retrieves the DatabaseService instance from the service manager.
 
     Returns:
@@ -139,7 +139,7 @@ def get_db_service() -> DatabaseService:
     """
     from langflow.services.database.organisation import OrganizationService
 
-    if get_settings_service().auth_settings.CLERK_AUTH_ENABLED:
+    if use_organisation and get_settings_service().auth_settings.CLERK_AUTH_ENABLED:
         return OrganizationService.get_db_service_for_request()
 
     from langflow.services.database.factory import DatabaseServiceFactory

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -132,7 +132,7 @@ async def teardown_superuser(settings_service, session: AsyncSession) -> None:
 async def teardown_services() -> None:
     """Teardown all the services."""
     try:
-        async with get_db_service().with_session() as session:
+        async with get_db_service(use_organisation=False).with_session() as session:
             await teardown_superuser(get_settings_service(), session)
     except Exception as exc:  # noqa: BLE001
         logger.exception(exc)
@@ -237,13 +237,13 @@ async def initialize_services(*, fix_migration: bool = False) -> None:
 
     # Setup the superuser
     await initialize_database(fix_migration=fix_migration)
-    db_service = get_db_service()
+    db_service = get_db_service(use_organisation=False)
     await db_service.initialize_alembic_log_file()
     async with db_service.with_session() as session:
         settings_service = get_service(ServiceType.SETTINGS_SERVICE)
         await setup_superuser(settings_service, session)
     try:
-        await get_db_service().assign_orphaned_flows_to_superuser()
+        await get_db_service(use_organisation=False).assign_orphaned_flows_to_superuser()
     except sqlalchemy_exc.IntegrityError as exc:
         logger.warning(f"Error assigning orphaned flows to the superuser: {exc!s}")
     await clean_transactions(settings_service, session)


### PR DESCRIPTION
## Summary
- allow `get_db_service` to fallback to base DB service unless organisation support is requested
- force startup routines to use base DB service

## Testing
- `pre-commit run --files src/backend/base/langflow/services/deps.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'langflow.components')*

------
https://chatgpt.com/codex/tasks/task_e_688f7d7e1020832693e137280e53bc82