### PR TITLE
Fix logout in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ dockerfile_build:
 		-f ${DOCKERFILE} \
 		--build-arg VITE_CLERK_AUTH_ENABLED=${VITE_CLERK_AUTH_ENABLED} \
 		--build-arg VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY} \
-		--build-arg LANGFLOW_AUTO_LOGIN=$(LANGFLOW_AUTO_LOGIN) \
+		--build-arg VITE_AUTO_LOGIN=$(VITE_AUTO_LOGIN) \
 		-t langflow:${VERSION} .
 
 dockerfile_build_be: dockerfile_build

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ DOCKERFILE=docker/build_and_push.Dockerfile
 DOCKERFILE_BACKEND=docker/build_and_push_backend.Dockerfile
 DOCKERFILE_FRONTEND=docker/frontend/build_and_push_frontend.Dockerfile
 DOCKER_COMPOSE=docker_example/docker-compose.yml
+
+VITE_CLERK_AUTH_ENABLED ?= false
+VITE_CLERK_PUBLISHABLE_KEY ?=
 PYTHON_REQUIRED=$(shell grep '^requires-python[[:space:]]*=' pyproject.toml | sed -n 's/.*"\([^"]*\)".*/\1/p')
 RED=\033[0;31m
 NC=\033[0m # No Color
@@ -333,6 +336,9 @@ dockerfile_build:
 	@echo 'BUILDING DOCKER IMAGE: ${DOCKERFILE}'
 	@docker build --rm \
 		-f ${DOCKERFILE} \
+		--build-arg VITE_CLERK_AUTH_ENABLED=${VITE_CLERK_AUTH_ENABLED} \
+		--build-arg VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY} \
+		--build-arg LANGFLOW_AUTO_LOGIN=$(LANGFLOW_AUTO_LOGIN) \
 		-t langflow:${VERSION} .
 
 dockerfile_build_be: dockerfile_build

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -44,8 +44,17 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY ./src /app/src
 
+ARG LANGFLOW_AUTO_LOGIN=true
+ENV LANGFLOW_AUTO_LOGIN=$LANGFLOW_AUTO_LOGIN
+    
 COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend
+
+ARG VITE_CLERK_AUTH_ENABLED=false
+ARG VITE_CLERK_PUBLISHABLE_KEY=""
+ENV VITE_CLERK_AUTH_ENABLED=$VITE_CLERK_AUTH_ENABLED
+ENV VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY
+
 RUN --mount=type=cache,target=/root/.npm \
     npm ci \
     && npm run build \

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -44,8 +44,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY ./src /app/src
 
-ARG LANGFLOW_AUTO_LOGIN=true
-ENV LANGFLOW_AUTO_LOGIN=$LANGFLOW_AUTO_LOGIN
+ARG VITE_AUTO_LOGIN=true
+ENV VITE_AUTO_LOGIN=$VITE_AUTO_LOGIN
     
 COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -1027,8 +1027,7 @@ export const POLLING_MESSAGES = {
 export const BUILD_POLLING_INTERVAL = 25;
 
 export const IS_AUTO_LOGIN =
-  !process?.env?.LANGFLOW_AUTO_LOGIN ||
-  String(process?.env?.LANGFLOW_AUTO_LOGIN)?.toLowerCase() !== "false";
+  import.meta.env.VITE_AUTO_LOGIN !== "false";
 
 export const AUTO_LOGIN_RETRY_DELAY = 2000;
 export const AUTO_LOGIN_MAX_RETRY_DELAY = 60000;


### PR DESCRIPTION
- Env Var Naming Fix for Vite
- 
-     Replaced LANGFLOW_AUTO_LOGIN with VITE_AUTO_LOGIN to align with Vite’s requirement: only env vars prefixed with VITE_ are exposed to import.meta.env in frontend code.
- 
-     Updated Dockerfile, frontend references, and build commands accordingly.
- 
-     Ensures auto login behavior is correctly controlled at build time using VITE_AUTO_LOGIN.
- 

ℹ️ Example usage:

DOCKER_BUILDKIT=1 \
VITE_AUTO_LOGIN=false \
VITE_CLERK_AUTH_ENABLED=true \
VITE_CLERK_PUBLISHABLE_KEY=pk_test_....\
make docker_build

docker run -p 7860:7860 --env-file .env langflow:1.4.2