### PR TITLE
chore: allow health check to bypass organisation db

### DIFF
--- a/src/backend/base/langflow/api/health_check_router.py
+++ b/src/backend/base/langflow/api/health_check_router.py
@@ -5,9 +5,9 @@ from loguru import logger
 from pydantic import BaseModel
 from sqlmodel import select
 
-from langflow.api.utils import DbSession
 from langflow.services.database.models.flow import Flow
 from langflow.services.deps import get_chat_service
+from langflow.services.deps_no_org import DbNoOrgSession
 
 health_check_router = APIRouter(tags=["Health Check"])
 
@@ -38,7 +38,7 @@ async def health():
 # It's a reliable health check for a langflow instance
 @health_check_router.get("/health_check")
 async def health_check(
-    session: DbSession,
+    session: DbNoOrgSession,
 ) -> HealthResponse:
     response = HealthResponse()
     # use a fixed valid UUId that UUID collision is very unlikely

--- a/src/backend/base/langflow/services/deps_no_org.py
+++ b/src/backend/base/langflow/services/deps_no_org.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from fastapi import Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from .deps import get_db_service
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+async def get_no_org_session() -> AsyncGenerator[AsyncSession, None]:
+    """Retrieve a database session without organisation scoping."""
+    async with get_db_service(use_organisation=False).with_session() as session:
+        yield session
+
+
+DbNoOrgSession = Annotated[AsyncSession, Depends(get_no_org_session)]


### PR DESCRIPTION
## Summary
- add dedicated `get_no_org_session` and `DbNoOrgSession`
- make health check endpoint use organisation-agnostic session
- restore `get_session` to always use organisation-aware db service

## Testing
- `pre-commit run --files src/backend/base/langflow/services/deps.py src/backend/base/langflow/services/deps_no_org.py src/backend/base/langflow/api/health_check_router.py`
- `PYTHONPATH=src/backend/base pytest -q src/backend/tests/unit/api/v1/test_endpoints.py::test_get_version` *(failed: ModuleNotFoundError: No module named 'anyio')*


------
https://chatgpt.com/codex/tasks/task_e_6890253721bc8326a3adbd6ae57e2ad4