### PR TITLE
Add .dockerignore to trim Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore Git repository and GitHub metadata
+.git
+.github
+.gitattributes
+.gitignore
+
+# Development and environment files
+.vscode
+.devcontainer
+.venv
+node_modules
+
+# Local configuration files
+.env
+.env.*
+.env-file
+
+# Documentation, examples, and test artifacts
+docs/
+docker_example/
+test-results/


### PR DESCRIPTION
## Summary
- ignore git metadata, docs, test artifacts, and local env files in Docker context

## Testing
- `pre-commit run --files .dockerignore`
- `pytest src/backend/tests/unit/test_schema.py` *(fails: ModuleNotFoundError: No module named 'langflow.components')*
- `docker build -f docker/dev.Dockerfile -t local/devtest .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c2df0b72b88326b6ffd6a73084508a