### PR TITLE
chore: add dockerignore to slim images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Exclude version control and GitHub metadata
+.git
+.gitignore
+.gitattributes
+.github
+
+# Documentation and test artifacts
+/docs
+/test-results
+/docker_example
+/scripts
+/deploy
+
+# Local development and editor files
+.vscode
+.devcontainer
+
+# Environment files and samples
+.env
+.env.*
+.env-file
+*.env
+*.example
+
+# Dependency directories and caches
+**/node_modules
+**/__pycache__
+*.py[cod]
+src/frontend/build
+.venv
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- reduce Docker build context by ignoring git history, docs, tests, and other non-essential files

## Testing
- `pre-commit run --files .dockerignore`
- `docker build -f docker/build_and_push.Dockerfile -t test-image .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e8db47908326bda4b2bd7b8bdf02