### PR TITLE
Redirect signed-in users away from Clerk login

### DIFF
--- a/src/frontend/src/clerk/login-pages.tsx
+++ b/src/frontend/src/clerk/login-pages.tsx
@@ -1,18 +1,24 @@
-import { SignIn, SignUp as ClerkSignUp, useAuth, useUser , useClerk, SignedOut} from "@clerk/clerk-react";
+import { SignIn, SignUp as ClerkSignUp, useAuth, useUser , useClerk, SignedOut, SignedIn} from "@clerk/clerk-react";
 import { lazy, useEffect, useState } from "react";
 import { useLogout } from "./auth";
+import { CustomNavigate } from "@/customization/components/custom-navigate";
 import { IS_CLERK_AUTH } from "@/clerk/auth";
 // Clerk login page component
 export function ClerkLoginPage() {
   return (
-    <SignedOut>
-      <div style={centeredStyle}>
-        <SignIn
-          afterSignInUrl="/organization"
-          redirectUrl="/organization"
-        />
-      </div>
-    </SignedOut>
+    <>
+      <SignedIn>
+        <CustomNavigate replace to="/organization" />
+      </SignedIn>
+      <SignedOut>
+        <div style={centeredStyle}>
+          <SignIn
+            afterSignInUrl="/organization"
+            redirectUrl="/organization"
+          />
+        </div>
+      </SignedOut>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a SignedIn guard on the Clerk login page that immediately navigates authenticated users to the organization selector
- keep the existing SignedOut login form unchanged for visitors who are not authenticated

## Testing
- npx prettier --check src/frontend/src/clerk/login-pages.tsx *(fails: Cannot find package 'prettier-plugin-organize-imports')*

------
https://chatgpt.com/codex/tasks/task_e_68cf92b193548326bc9f7c53de53c510