### PR TITLE
Refactor public routing to defer heavy providers and Clerk

### DIFF
--- a/src/frontend/src/clerk/auth.tsx
+++ b/src/frontend/src/clerk/auth.tsx
@@ -1,4 +1,4 @@
-import { lazy, ReactNode, useContext, useEffect, useRef } from "react";
+import { ReactNode, useContext, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { AuthContext } from "@/contexts/authContext";
 import { api } from "@/controllers/API/api";
@@ -8,14 +8,12 @@ import { ClerkProvider, useAuth, useClerk, useOrganization, useUser, SignedOut }
 import { Users } from "@/types/api";
 import { LANGFLOW_ACCESS_TOKEN, LANGFLOW_REFRESH_TOKEN } from "@/constants/constants";
 import { Cookies } from "react-cookie";
-import OrganizationPage from "./OrganizationPage";
 import authStore from "@/stores/authStore";
-
-export const IS_CLERK_AUTH =
-  String(import.meta.env.VITE_CLERK_AUTH_ENABLED).toLowerCase() === "true";
-
-export const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || "";
-export const CLERK_DUMMY_PASSWORD = "clerk_dummy_password";
+import {
+  CLERK_DUMMY_PASSWORD,
+  CLERK_PUBLISHABLE_KEY,
+  IS_CLERK_AUTH,
+} from "@/clerk/config";
 
 export enum HttpStatusCode {
   UNAUTHORIZED = 401,

--- a/src/frontend/src/clerk/config.ts
+++ b/src/frontend/src/clerk/config.ts
@@ -1,0 +1,7 @@
+export const IS_CLERK_AUTH =
+  String(import.meta.env.VITE_CLERK_AUTH_ENABLED).toLowerCase() === "true";
+
+export const CLERK_PUBLISHABLE_KEY =
+  import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || "";
+
+export const CLERK_DUMMY_PASSWORD = "clerk_dummy_password";

--- a/src/frontend/src/clerk/login-pages.tsx
+++ b/src/frontend/src/clerk/login-pages.tsx
@@ -1,7 +1,7 @@
 import { SignIn, SignUp as ClerkSignUp, useAuth, useUser , useClerk, SignedOut} from "@clerk/clerk-react";
 import { lazy, useEffect, useState } from "react";
 import { useLogout } from "./auth";
-import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 // Clerk login page component
 export function ClerkLoginPage() {
   return (

--- a/src/frontend/src/components/authorization/authLoginGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authLoginGuard/index.tsx
@@ -1,7 +1,7 @@
 import { CustomNavigate } from "@/customization/components/custom-navigate";
 import useAuthStore from "@/stores/authStore";
 import { useOrganization } from "@clerk/clerk-react";
-import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 import { useLocation } from "react-router-dom";
 
 export const ProtectedLoginRoute = ({ children }) => {

--- a/src/frontend/src/contexts/index.tsx
+++ b/src/frontend/src/contexts/index.tsx
@@ -6,7 +6,8 @@ import { ReactNode } from "react";
 import { TooltipProvider } from "../components/ui/tooltip";
 import { ApiInterceptor } from "../controllers/API/api";
 import { AuthProvider } from "./authContext";
-import { ClerkAuthAdapter, IS_CLERK_AUTH } from "@/clerk/auth";
+import { ClerkAuthAdapter } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 
 export default function ContextWrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient();

--- a/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
@@ -13,7 +13,7 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 import { useLogout } from "./use-post-logout";
-import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 
 export interface AutoLoginResponse {
   frontend_timeout: number;

--- a/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
@@ -1,4 +1,5 @@
-import { mockClerkMutation ,IS_CLERK_AUTH } from "@/clerk/auth";
+import { mockClerkMutation } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 import { IS_AUTO_LOGIN, LANGFLOW_REFRESH_TOKEN } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";

--- a/src/frontend/src/customization/components/ClerkAccountMenu.tsx
+++ b/src/frontend/src/customization/components/ClerkAccountMenu.tsx
@@ -1,5 +1,6 @@
 import { UserButton } from "@clerk/clerk-react";
-import { IS_CLERK_AUTH, useLogout } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
+import { useLogout } from "@/clerk/auth";
 import { LogOut } from "lucide-react";
 import { AccountMenu } from "@/components/core/appHeaderComponent/components/AccountMenu";
 

--- a/src/frontend/src/pages/AppInitPage/index.tsx
+++ b/src/frontend/src/pages/AppInitPage/index.tsx
@@ -9,7 +9,7 @@ import { CustomLoadingPage } from "@/customization/components/custom-loading-pag
 import { useCustomPrimaryLoading } from "@/customization/hooks/use-custom-primary-loading";
 import { useDarkStore } from "@/stores/darkStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
-import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { IS_CLERK_AUTH } from "@/clerk/config";
 import { useOrganization } from "@clerk/clerk-react";
 import useAuthStore from "@/stores/authStore";
 

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -7,9 +7,7 @@ import {
 } from "react-router-dom";
 import { ProtectedAdminRoute } from "./components/authorization/authAdminGuard";
 import { ProtectedRoute } from "./components/authorization/authGuard";
-import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
 import { AuthSettingsGuard } from "./components/authorization/authSettingsGuard";
-import ContextWrapper from "./contexts";
 import { CustomNavigate } from "./customization/components/custom-navigate";
 import { BASENAME } from "./customization/config-constants";
 import {
@@ -18,14 +16,17 @@ import {
 } from "./customization/feature-flags";
 import { CustomRoutesStore } from "./customization/utils/custom-routes-store";
 import { CustomRoutesStorePages } from "./customization/utils/custom-routes-store-pages";
-import { IS_CLERK_AUTH } from "./clerk/auth";
+import { IS_CLERK_AUTH } from "./clerk/config";
 import { LoadingPage } from "./pages/LoadingPage";
+import useAuthStore from "./stores/authStore";
 
 const AppWrapperPage = lazy(() =>
   import("./pages/AppWrapperPage").then((module) => ({
     default: module.AppWrapperPage,
   })),
 );
+const LandingPage = lazy(() => import("./pages/LandingPage"));
+const ContextWrapper = lazy(() => import("./contexts"));
 const AppInitPage = lazy(() =>
   import("./pages/AppInitPage").then((module) => ({
     default: module.AppInitPage,
@@ -75,9 +76,30 @@ const LoginAdminPage = lazy(() =>
   })),
 );
 
+const ProtectedLoginRoute = lazy(() =>
+  import("./components/authorization/authLoginGuard").then((module) => ({
+    default: module.ProtectedLoginRoute,
+  })),
+);
+
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 const PlaygroundPage = lazy(() => import("./pages/Playground"));
+
+function LandingEntryRoute() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  if (isAuthenticated) {
+    const target = IS_CLERK_AUTH ? "/organization" : "flows";
+    return <CustomNavigate replace to={target} />;
+  }
+
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <LandingPage />
+    </Suspense>
+  );
+}
 
 const router = createBrowserRouter(
   createRoutesFromElements([
@@ -85,27 +107,65 @@ const router = createBrowserRouter(
       <Route
         path=""
         element={
-          <ContextWrapper key={1}>
-            <Suspense fallback={<LoadingPage />}>
+          <Suspense fallback={<LoadingPage />}>
+            <ContextWrapper key={1}>
               <PlaygroundPage />
-            </Suspense>
-          </ContextWrapper>
+            </ContextWrapper>
+          </Suspense>
         }
       />
     </Route>,
     <Route
       path={ENABLE_CUSTOM_PARAM ? "/:customParam?" : "/"}
-      element={
-        <ContextWrapper key={2}>
-          <Outlet />
-        </ContextWrapper>
-      }
+      element={<Outlet />}
     >
+      <Route index element={<LandingEntryRoute />} />
       <Route
-        path=""
+        path="login"
         element={
           <Suspense fallback={<LoadingPage />}>
-            <AppWrapperPage />
+            <ProtectedLoginRoute>
+              <LoginPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="organization"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <OrganizationPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="signup"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <SignUp />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="login/admin"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginAdminPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ContextWrapper key={2}>
+              <Outlet />
+            </ContextWrapper>
           </Suspense>
         }
       >
@@ -113,9 +173,7 @@ const router = createBrowserRouter(
           path=""
           element={
             <Suspense fallback={<LoadingPage />}>
-              <ProtectedRoute>
-                <AppInitPage />
-              </ProtectedRoute>
+              <AppWrapperPage />
             </Suspense>
           }
         >
@@ -123,7 +181,9 @@ const router = createBrowserRouter(
             path=""
             element={
               <Suspense fallback={<LoadingPage />}>
-                <AppAuthenticatedPage />
+                <ProtectedRoute>
+                  <AppInitPage />
+                </ProtectedRoute>
               </Suspense>
             }
           >
@@ -131,174 +191,10 @@ const router = createBrowserRouter(
               path=""
               element={
                 <Suspense fallback={<LoadingPage />}>
-                  <CustomDashboardWrapperPage />
+                  <AppAuthenticatedPage />
                 </Suspense>
               }
             >
-              <Route
-                path=""
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <CollectionPage />
-                  </Suspense>
-                }
-              >
-                <Route
-                  index
-                  element={
-                    IS_CLERK_AUTH ? (
-                      <CustomNavigate replace to="/organization" />
-                    ) : (
-                      <CustomNavigate replace to="flows" />
-                    )
-                  }
-                />
-                {ENABLE_FILE_MANAGEMENT && (
-                  <Route
-                    path="files"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <FilesPage />
-                      </Suspense>
-                    }
-                  />
-                )}
-                <Route
-                  path="flows/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="components/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="components" type="components" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="components" type="components" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="all/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="flows" type="flows" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="mcp/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="mcp" type="mcp" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="mcp" type="mcp" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-              </Route>
-              <Route
-                path="settings"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <SettingsPage />
-                  </Suspense>
-                }
-              >
-                <Route index element={<CustomNavigate replace to="general" />} />
-                <Route
-                  path="global-variables"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <GlobalVariablesPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="api-keys"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ApiKeysPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="general/:scrollId?"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <AuthSettingsGuard>
-                        <GeneralPage />
-                      </AuthSettingsGuard>
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="shortcuts"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ShortcutsPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="messages"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <MessagesPage />
-                    </Suspense>
-                  }
-                />
-                {CustomRoutesStore()}
-              </Route>
-              {CustomRoutesStorePages()}
-              <Route path="account">
-                <Route
-                  path="delete"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <DeleteAccountPage />
-                    </Suspense>
-                  }
-                />
-              </Route>
-              <Route
-                path="admin"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ProtectedAdminRoute>
-                      <AdminPage />
-                    </ProtectedAdminRoute>
-                  </Suspense>
-                }
-              />
-            </Route>
-            <Route path="flow/:id/">
               <Route
                 path=""
                 element={
@@ -308,76 +204,209 @@ const router = createBrowserRouter(
                 }
               >
                 <Route
-                  path="folder/:folderId/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <FlowPage />
-                    </Suspense>
-                  }
-                />
-                <Route
                   path=""
                   element={
                     <Suspense fallback={<LoadingPage />}>
-                      <FlowPage />
+                      <CollectionPage />
+                    </Suspense>
+                  }
+                >
+                  <Route
+                    index
+                    element={
+                      IS_CLERK_AUTH ? (
+                        <CustomNavigate replace to="/organization" />
+                      ) : (
+                        <CustomNavigate replace to="flows" />
+                      )
+                    }
+                  />
+                  {ENABLE_FILE_MANAGEMENT && (
+                    <Route
+                      path="files"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <FilesPage />
+                        </Suspense>
+                      }
+                    />
+                  )}
+                  <Route
+                    path="flows/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="flows" type="flows" />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="components/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="components" type="components" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="components" type="components" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                  <Route
+                    path="all/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="flows" type="flows" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="flows" type="flows" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                  <Route
+                    path="mcp/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="mcp" type="mcp" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="mcp" type="mcp" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                </Route>
+                <Route
+                  path="settings"
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <SettingsPage />
+                    </Suspense>
+                  }
+                >
+                  <Route index element={<CustomNavigate replace to="general" />} />
+                  <Route
+                    path="global-variables"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <GlobalVariablesPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="api-keys"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <ApiKeysPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="general/:scrollId?"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <AuthSettingsGuard>
+                          <GeneralPage />
+                        </AuthSettingsGuard>
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="shortcuts"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <ShortcutsPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="messages"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <MessagesPage />
+                      </Suspense>
+                    }
+                  />
+                  {CustomRoutesStore()}
+                </Route>
+                {CustomRoutesStorePages()}
+                <Route path="account">
+                  <Route
+                    path="delete"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <DeleteAccountPage />
+                      </Suspense>
+                    }
+                  />
+                </Route>
+                <Route
+                  path="admin"
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <ProtectedAdminRoute>
+                        <AdminPage />
+                      </ProtectedAdminRoute>
                     </Suspense>
                   }
                 />
               </Route>
-              <Route
-                path="view"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ViewPage />
-                  </Suspense>
-                }
-              />
+              <Route path="flow/:id/">
+                <Route
+                  path=""
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <CustomDashboardWrapperPage />
+                    </Suspense>
+                  }
+                >
+                  <Route
+                    path="folder/:folderId/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <FlowPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path=""
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <FlowPage />
+                      </Suspense>
+                    }
+                  />
+                </Route>
+                <Route
+                  path="view"
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <ViewPage />
+                    </Suspense>
+                  }
+                />
+              </Route>
             </Route>
           </Route>
         </Route>
-        <Route
-          path="login"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="organization"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <OrganizationPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="signup"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <SignUp />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="login/admin"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginAdminPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
       </Route>
-      <Route path="*" element={<CustomNavigate replace to="/" />} />
     </Route>,
+    <Route path="*" element={<CustomNavigate replace to="/" />} />,
   ]),
   { basename: BASENAME || undefined },
 );

--- a/src/frontend/src/stores/authStore.ts
+++ b/src/frontend/src/stores/authStore.ts
@@ -1,4 +1,5 @@
 // authStore.js
+import { IS_CLERK_AUTH } from "@/clerk/config";
 import { LANGFLOW_ACCESS_TOKEN } from "@/constants/constants";
 import { AuthStoreType } from "@/types/zustand/auth";
 import { Cookies } from "react-cookie";
@@ -13,16 +14,7 @@ const useAuthStore = create<AuthStoreType>((set, get) => ({
   autoLogin: null,
   apiKey: cookies.get("apikey_tkn_lflw"),
   authenticationErrorCount: 0,
-  isOrgSelected: (() => {
-    try {
-      // Dynamically import IS_CLERK_AUTH to avoid circular deps
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { IS_CLERK_AUTH } = require("@/clerk/auth");
-      return IS_CLERK_AUTH ? false : undefined;
-    } catch {
-      return undefined;
-    }
-  })(),
+  isOrgSelected: IS_CLERK_AUTH ? false : undefined,
 
   setIsAdmin: (isAdmin) => set({ isAdmin }),
   setIsAuthenticated: (isAuthenticated) => set({ isAuthenticated }),


### PR DESCRIPTION
## Summary
- move marketing and login routes into a lightweight layout that lazily loads the heavy app providers
- add a dedicated Clerk config module and update callers to avoid pulling Clerk bundles into public pages
- adjust auth store and guards to rely on the new config and keep Clerk-protected logic behind lazy boundaries

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d245347a4883268bd2c0aca243405e