### PR TITLE
Create public router shell for unauthenticated pages

### DIFF
--- a/src/frontend/src/pages/AppWrapperPage/index.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/index.tsx
@@ -1,22 +1,12 @@
 import AlertDisplayArea from "@/alerts/displayArea";
 import CrashErrorComponent from "@/components/common/crashErrorComponent";
 import { ErrorBoundary } from "react-error-boundary";
-import useAuthStore from "@/stores/authStore";
-import { Outlet , useLocation } from "react-router-dom";
-import Landing from "../LandingPage";
+import { Outlet } from "react-router-dom";
 import { GenericErrorComponent } from "./components/GenericErrorComponent";
 import { useHealthCheck } from "./hooks/use-health-check";
 
 export function AppWrapperPage() {
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const { pathname } = useLocation();
   const { healthCheckTimeout, fetchingHealth, refetch } = useHealthCheck();
-
-  // Render the marketing landing page instead of the authenticated app shell
-  // when a visitor hits the root route without an active session.
-  if (!isAuthenticated && pathname === "/") {
-    return <Landing />;
-  }
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/src/frontend/src/pages/PublicShell/index.tsx
+++ b/src/frontend/src/pages/PublicShell/index.tsx
@@ -1,0 +1,26 @@
+import { CustomNavigate } from "@/customization/components/custom-navigate";
+import { ENABLE_CUSTOM_PARAM } from "@/customization/feature-flags";
+import Landing from "@/pages/LandingPage";
+import useAuthStore from "@/stores/authStore";
+import type { JSX } from "react";
+import { Outlet, useParams } from "react-router-dom";
+
+export function PublicShell(): JSX.Element {
+  return <Outlet />;
+}
+
+export function PublicLandingRoute(): JSX.Element {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { customParam } = useParams();
+
+  if (isAuthenticated) {
+    const flowsPath =
+      ENABLE_CUSTOM_PARAM && customParam
+        ? `/${customParam}/flows`
+        : "/flows";
+
+    return <CustomNavigate replace to={flowsPath} />;
+  }
+
+  return <Landing />;
+}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -20,6 +20,7 @@ import { CustomRoutesStore } from "./customization/utils/custom-routes-store";
 import { CustomRoutesStorePages } from "./customization/utils/custom-routes-store-pages";
 import { IS_CLERK_AUTH } from "./clerk/auth";
 import { LoadingPage } from "./pages/LoadingPage";
+import { PublicLandingRoute, PublicShell } from "./pages/PublicShell";
 
 const AppWrapperPage = lazy(() =>
   import("./pages/AppWrapperPage").then((module) => ({
@@ -81,6 +82,58 @@ const PlaygroundPage = lazy(() => import("./pages/Playground"));
 
 const router = createBrowserRouter(
   createRoutesFromElements([
+    <Route element={<PublicShell />}>
+      <Route
+        path="/"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <PublicLandingRoute />
+          </Suspense>
+        }
+      />
+      <Route
+        path={ENABLE_CUSTOM_PARAM ? "/:customParam?/login" : "/login"}
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path={ENABLE_CUSTOM_PARAM ? "/:customParam?/organization" : "/organization"}
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <OrganizationPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path={ENABLE_CUSTOM_PARAM ? "/:customParam?/signup" : "/signup"}
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <SignUp />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path={
+          ENABLE_CUSTOM_PARAM ? "/:customParam?/login/admin" : "/login/admin"
+        }
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginAdminPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+    </Route>,
     <Route path="/playground/:id/">
       <Route
         path=""
@@ -335,46 +388,6 @@ const router = createBrowserRouter(
             </Route>
           </Route>
         </Route>
-        <Route
-          path="login"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="organization"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <OrganizationPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="signup"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <SignUp />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="login/admin"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginAdminPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
       </Route>
       <Route path="*" element={<CustomNavigate replace to="/" />} />
     </Route>,


### PR DESCRIPTION
## Summary
- add a lightweight PublicShell layout to host landing and auth-related screens outside the heavy ContextWrapper tree
- redirect authenticated visitors away from the public landing route while keeping feature-flag based custom parameters intact
- simplify AppWrapperPage so it only renders the authenticated shell now that landing content lives in the public router branch

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d27315544c8326b43ce7b4638a6625