### PR TITLE
Add public layout for marketing and auth routes

### DIFF
--- a/src/frontend/src/contexts/PublicLayout.tsx
+++ b/src/frontend/src/contexts/PublicLayout.tsx
@@ -1,0 +1,16 @@
+import { GradientWrapper } from "@/components/common/GradientWrapper";
+import { CustomWrapper } from "@/customization/custom-wrapper";
+import { ReactNode } from "react";
+import { Outlet } from "react-router-dom";
+
+export function PublicLayout({ children }: { children?: ReactNode }) {
+  const content = children ?? <Outlet />;
+
+  return (
+    <CustomWrapper>
+      <GradientWrapper>{content}</GradientWrapper>
+    </CustomWrapper>
+  );
+}
+
+export default PublicLayout;

--- a/src/frontend/src/pages/AppWrapperPage/index.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/index.tsx
@@ -1,22 +1,12 @@
 import AlertDisplayArea from "@/alerts/displayArea";
 import CrashErrorComponent from "@/components/common/crashErrorComponent";
 import { ErrorBoundary } from "react-error-boundary";
-import useAuthStore from "@/stores/authStore";
-import { Outlet , useLocation } from "react-router-dom";
-import Landing from "../LandingPage";
+import { Outlet } from "react-router-dom";
 import { GenericErrorComponent } from "./components/GenericErrorComponent";
 import { useHealthCheck } from "./hooks/use-health-check";
 
 export function AppWrapperPage() {
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const { pathname } = useLocation();
   const { healthCheckTimeout, fetchingHealth, refetch } = useHealthCheck();
-
-  // Render the marketing landing page instead of the authenticated app shell
-  // when a visitor hits the root route without an active session.
-  if (!isAuthenticated && pathname === "/") {
-    return <Landing />;
-  }
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/src/frontend/src/pages/LoginPage/index.tsx
+++ b/src/frontend/src/pages/LoginPage/index.tsx
@@ -1,28 +1,39 @@
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
-import { useLoginUser } from "@/controllers/API/queries/auth";
 import { CustomLink } from "@/customization/components/custom-link";
 import * as Form from "@radix-ui/react-form";
-import { useContext, useState } from "react";
+import { useState, useCallback } from "react";
 import InputComponent from "../../components/core/parameterRenderComponent/components/inputComponent";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { SIGNIN_ERROR_ALERT } from "../../constants/alerts_constants";
 import { CONTROL_LOGIN_STATE } from "../../constants/constants";
-import { AuthContext } from "../../contexts/authContext";
 import useAlertStore from "../../stores/alertStore";
 import { LoginType } from "../../types/api";
 import {
   inputHandlerEventType,
   loginInputStateType,
 } from "../../types/components";
+import { api } from "@/controllers/API/api";
+import { getURL } from "@/controllers/API/helpers/constants";
+import { Cookies } from "react-cookie";
+import {
+  LANGFLOW_ACCESS_TOKEN,
+  LANGFLOW_AUTO_LOGIN_OPTION,
+  LANGFLOW_REFRESH_TOKEN,
+} from "@/constants/constants";
+import { setLocalStorage } from "@/utils/local-storage-util";
+import useAuthStore from "@/stores/authStore";
 
 export default function LoginPage(): JSX.Element {
   const [inputState, setInputState] =
     useState<loginInputStateType>(CONTROL_LOGIN_STATE);
 
   const { password, username } = inputState;
-  const { login } = useContext(AuthContext);
   const setErrorData = useAlertStore((state) => state.setErrorData);
+  const setIsAuthenticated = useAuthStore((state) => state.setIsAuthenticated);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setAutoLogin = useAuthStore((state) => state.setAutoLogin);
+  const cookies = new Cookies();
 
   function handleInput({
     target: { name, value },
@@ -30,26 +41,50 @@ export default function LoginPage(): JSX.Element {
     setInputState((prev) => ({ ...prev, [name]: value }));
   }
 
-  const { mutate } = useLoginUser();
-
-  function signIn() {
+  const signIn = useCallback(async () => {
     const user: LoginType = {
       username: username.trim(),
       password: password.trim(),
     };
 
-    mutate(user, {
-      onSuccess: (data) => {
-        login(data.access_token, "login", data.refresh_token);
-      },
-      onError: (error) => {
-        setErrorData({
-          title: SIGNIN_ERROR_ALERT,
-          list: [error["response"]["data"]["detail"]],
+    try {
+      const response = await api.post(
+        `${getURL("LOGIN")}`,
+        new URLSearchParams({
+          username: user.username,
+          password: user.password,
+        }).toString(),
+        {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        },
+      );
+
+      const data = response.data;
+      cookies.set(LANGFLOW_ACCESS_TOKEN, data.access_token, { path: "/" });
+      cookies.set(LANGFLOW_AUTO_LOGIN_OPTION, "login", { path: "/" });
+
+      setLocalStorage(LANGFLOW_ACCESS_TOKEN, data.access_token);
+
+      if (data.refresh_token) {
+        cookies.set(LANGFLOW_REFRESH_TOKEN, data.refresh_token, {
+          path: "/",
         });
-      },
-    });
-  }
+      }
+
+      setAccessToken(data.access_token);
+      setIsAuthenticated(true);
+      setAutoLogin(false);
+    } catch (error: any) {
+      const detail =
+        error?.response?.data?.detail || "Failed to sign in. Please try again.";
+      setErrorData({
+        title: SIGNIN_ERROR_ALERT,
+        list: [detail],
+      });
+    }
+  }, [username, password, cookies, setErrorData, setAccessToken, setIsAuthenticated, setAutoLogin]);
 
   return (
     <Form.Root

--- a/src/frontend/src/pages/PublicLandingPage/index.tsx
+++ b/src/frontend/src/pages/PublicLandingPage/index.tsx
@@ -1,0 +1,22 @@
+import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { CustomNavigate } from "@/customization/components/custom-navigate";
+import useAuthStore from "@/stores/authStore";
+import Landing from "../LandingPage";
+
+export function PublicLandingPage() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const autoLogin = useAuthStore((state) => state.autoLogin);
+
+  if (isAuthenticated || autoLogin) {
+    return (
+      <CustomNavigate
+        replace
+        to={IS_CLERK_AUTH ? "/organization" : "/flows"}
+      />
+    );
+  }
+
+  return <Landing />;
+}
+
+export default PublicLandingPage;

--- a/src/frontend/src/pages/SignUpPage/index.tsx
+++ b/src/frontend/src/pages/SignUpPage/index.tsx
@@ -1,6 +1,5 @@
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 import InputComponent from "@/components/core/parameterRenderComponent/components/inputComponent";
-import { useAddUser } from "@/controllers/API/queries/auth";
 import { CustomLink } from "@/customization/components/custom-link";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
@@ -19,6 +18,8 @@ import {
   inputHandlerEventType,
   signUpInputStateType,
 } from "../../types/components";
+import { api } from "@/controllers/API/api";
+import { getURL } from "@/controllers/API/helpers/constants";
 
 export default function SignUp(): JSX.Element {
   const [inputState, setInputState] =
@@ -30,8 +31,6 @@ export default function SignUp(): JSX.Element {
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const navigate = useCustomNavigate();
-
-  const { mutate: mutateAddUser } = useAddUser();
 
   function handleInput({
     target: { name, value },
@@ -53,26 +52,22 @@ export default function SignUp(): JSX.Element {
       password: password.trim(),
     };
 
-    mutateAddUser(newUser, {
-      onSuccess: (user) => {
-        track("User Signed Up", user);
+    api
+      .post(`${getURL("USERS")}/`, newUser)
+      .then((response) => {
+        track("User Signed Up", response.data);
         setSuccessData({
           title: SIGN_UP_SUCCESS,
         });
         navigate("/login");
-      },
-      onError: (error) => {
-        const {
-          response: {
-            data: { detail },
-          },
-        } = error;
+      })
+      .catch((error) => {
+        const detail = error?.response?.data?.detail ?? "Unable to sign up.";
         setErrorData({
           title: SIGNUP_ERROR_ALERT,
           list: [detail],
         });
-      },
-    });
+      });
   }
 
   return (

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -10,6 +10,7 @@ import { ProtectedRoute } from "./components/authorization/authGuard";
 import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
 import { AuthSettingsGuard } from "./components/authorization/authSettingsGuard";
 import ContextWrapper from "./contexts";
+import PublicLayout from "./contexts/PublicLayout";
 import { CustomNavigate } from "./customization/components/custom-navigate";
 import { BASENAME } from "./customization/config-constants";
 import {
@@ -74,6 +75,11 @@ const LoginAdminPage = lazy(() =>
     default: module.LoginAdminPage,
   })),
 );
+const PublicLandingPage = lazy(() =>
+  import("./pages/PublicLandingPage").then((module) => ({
+    default: module.PublicLandingPage,
+  })),
+);
 
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
@@ -90,6 +96,46 @@ const router = createBrowserRouter(
               <PlaygroundPage />
             </Suspense>
           </ContextWrapper>
+        }
+      />
+    </Route>,
+    <Route element={<PublicLayout />}>
+      <Route
+        path="/"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <PublicLandingPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="/login"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/signup"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <SignUp />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/login/admin"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginAdminPage />
+            </ProtectedLoginRoute>
+          </Suspense>
         }
       />
     </Route>,
@@ -336,41 +382,11 @@ const router = createBrowserRouter(
           </Route>
         </Route>
         <Route
-          path="login"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
           path="organization"
           element={
             <Suspense fallback={<LoadingPage />}>
               <ProtectedLoginRoute>
                 <OrganizationPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="signup"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <SignUp />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="login/admin"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginAdminPage />
               </ProtectedLoginRoute>
             </Suspense>
           }


### PR DESCRIPTION
## Summary
- add a lightweight PublicLayout wrapper for marketing and authentication pages
- move landing, login, and signup routes out of the heavy app shell into the public layout
- refactor login and signup forms to call the API directly so they no longer depend on React Query providers

## Testing
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d3a860debc8326820432e8aa71b577