### PR TITLE
refactor: add public layout for marketing routes

### DIFF
--- a/src/frontend/src/contexts/index.tsx
+++ b/src/frontend/src/contexts/index.tsx
@@ -2,14 +2,14 @@ import { GradientWrapper } from "@/components/common/GradientWrapper";
 import { CustomWrapper } from "@/customization/custom-wrapper";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactFlowProvider } from "@xyflow/react";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { TooltipProvider } from "../components/ui/tooltip";
 import { ApiInterceptor } from "../controllers/API/api";
 import { AuthProvider } from "./authContext";
 import { ClerkAuthAdapter, IS_CLERK_AUTH } from "@/clerk/auth";
 
 export default function ContextWrapper({ children }: { children: ReactNode }) {
-  const queryClient = new QueryClient();
+  const [queryClient] = useState(() => new QueryClient());
   //element to wrap all context
   return (
     <>
@@ -29,5 +29,23 @@ export default function ContextWrapper({ children }: { children: ReactNode }) {
         </GradientWrapper>
       </CustomWrapper>
     </>
+  );
+}
+
+export function PublicLayout({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <CustomWrapper>
+      <GradientWrapper>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            {IS_CLERK_AUTH && <ClerkAuthAdapter />}
+            <ApiInterceptor />
+            {children}
+          </AuthProvider>
+        </QueryClientProvider>
+      </GradientWrapper>
+    </CustomWrapper>
   );
 }

--- a/src/frontend/src/pages/AppWrapperPage/index.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/index.tsx
@@ -1,22 +1,12 @@
 import AlertDisplayArea from "@/alerts/displayArea";
 import CrashErrorComponent from "@/components/common/crashErrorComponent";
 import { ErrorBoundary } from "react-error-boundary";
-import useAuthStore from "@/stores/authStore";
-import { Outlet , useLocation } from "react-router-dom";
-import Landing from "../LandingPage";
+import { Outlet } from "react-router-dom";
 import { GenericErrorComponent } from "./components/GenericErrorComponent";
 import { useHealthCheck } from "./hooks/use-health-check";
 
 export function AppWrapperPage() {
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const { pathname } = useLocation();
   const { healthCheckTimeout, fetchingHealth, refetch } = useHealthCheck();
-
-  // Render the marketing landing page instead of the authenticated app shell
-  // when a visitor hits the root route without an active session.
-  if (!isAuthenticated && pathname === "/") {
-    return <Landing />;
-  }
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/src/frontend/src/pages/LandingPage/index.tsx
+++ b/src/frontend/src/pages/LandingPage/index.tsx
@@ -1,8 +1,10 @@
 import { motion, AnimatePresence } from "framer-motion";
 import type { JSX, SVGProps } from "react";
 import VisualWorkflow from "../../assets/VisualWorkflow.png";
-import { useState } from "react";
-
+import { useEffect, useState } from "react";
+import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import useAuthStore from "@/stores/authStore";
+import { IS_CLERK_AUTH } from "@/clerk/auth";
 
 function CheckIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -25,6 +27,14 @@ function PlayIcon(props: SVGProps<SVGSVGElement>) {
 
 export default function Landing(): JSX.Element {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navigate = useCustomNavigate();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(IS_CLERK_AUTH ? "/organization" : "/flows", { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
   return (
     <div className="h-screen overflow-y-auto bg-[#0f1217] text-white">
       {/* Background accents */}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -9,7 +9,7 @@ import { ProtectedAdminRoute } from "./components/authorization/authAdminGuard";
 import { ProtectedRoute } from "./components/authorization/authGuard";
 import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
 import { AuthSettingsGuard } from "./components/authorization/authSettingsGuard";
-import ContextWrapper from "./contexts";
+import ContextWrapper, { PublicLayout } from "./contexts";
 import { CustomNavigate } from "./customization/components/custom-navigate";
 import { BASENAME } from "./customization/config-constants";
 import {
@@ -26,6 +26,7 @@ const AppWrapperPage = lazy(() =>
     default: module.AppWrapperPage,
   })),
 );
+const LandingPage = lazy(() => import("./pages/LandingPage"));
 const AppInitPage = lazy(() =>
   import("./pages/AppInitPage").then((module) => ({
     default: module.AppInitPage,
@@ -95,27 +96,20 @@ const router = createBrowserRouter(
     </Route>,
     <Route
       path={ENABLE_CUSTOM_PARAM ? "/:customParam?" : "/"}
-      element={
-        <ContextWrapper key={2}>
-          <Outlet />
-        </ContextWrapper>
-      }
+      element={<PublicLayout />}
     >
       <Route
-        path=""
         element={
-          <Suspense fallback={<LoadingPage />}>
-            <AppWrapperPage />
-          </Suspense>
+          <ContextWrapper key={2}>
+            <Outlet />
+          </ContextWrapper>
         }
       >
         <Route
           path=""
           element={
             <Suspense fallback={<LoadingPage />}>
-              <ProtectedRoute>
-                <AppInitPage />
-              </ProtectedRoute>
+              <AppWrapperPage />
             </Suspense>
           }
         >
@@ -123,7 +117,9 @@ const router = createBrowserRouter(
             path=""
             element={
               <Suspense fallback={<LoadingPage />}>
-                <AppAuthenticatedPage />
+                <ProtectedRoute>
+                  <AppInitPage />
+                </ProtectedRoute>
               </Suspense>
             }
           >
@@ -131,174 +127,10 @@ const router = createBrowserRouter(
               path=""
               element={
                 <Suspense fallback={<LoadingPage />}>
-                  <CustomDashboardWrapperPage />
+                  <AppAuthenticatedPage />
                 </Suspense>
               }
             >
-              <Route
-                path=""
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <CollectionPage />
-                  </Suspense>
-                }
-              >
-                <Route
-                  index
-                  element={
-                    IS_CLERK_AUTH ? (
-                      <CustomNavigate replace to="/organization" />
-                    ) : (
-                      <CustomNavigate replace to="flows" />
-                    )
-                  }
-                />
-                {ENABLE_FILE_MANAGEMENT && (
-                  <Route
-                    path="files"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <FilesPage />
-                      </Suspense>
-                    }
-                  />
-                )}
-                <Route
-                  path="flows/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="components/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="components" type="components" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="components" type="components" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="all/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="flows" type="flows" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="mcp/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="mcp" type="mcp" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="mcp" type="mcp" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-              </Route>
-              <Route
-                path="settings"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <SettingsPage />
-                  </Suspense>
-                }
-              >
-                <Route index element={<CustomNavigate replace to="general" />} />
-                <Route
-                  path="global-variables"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <GlobalVariablesPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="api-keys"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ApiKeysPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="general/:scrollId?"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <AuthSettingsGuard>
-                        <GeneralPage />
-                      </AuthSettingsGuard>
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="shortcuts"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ShortcutsPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="messages"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <MessagesPage />
-                    </Suspense>
-                  }
-                />
-                {CustomRoutesStore()}
-              </Route>
-              {CustomRoutesStorePages()}
-              <Route path="account">
-                <Route
-                  path="delete"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <DeleteAccountPage />
-                    </Suspense>
-                  }
-                />
-              </Route>
-              <Route
-                path="admin"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ProtectedAdminRoute>
-                      <AdminPage />
-                    </ProtectedAdminRoute>
-                  </Suspense>
-                }
-              />
-            </Route>
-            <Route path="flow/:id/">
               <Route
                 path=""
                 element={
@@ -308,59 +140,185 @@ const router = createBrowserRouter(
                 }
               >
                 <Route
-                  path="folder/:folderId/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <FlowPage />
-                    </Suspense>
-                  }
-                />
-                <Route
                   path=""
                   element={
                     <Suspense fallback={<LoadingPage />}>
-                      <FlowPage />
+                      <CollectionPage />
+                    </Suspense>
+                  }
+                >
+                  <Route
+                    index
+                    element={
+                      IS_CLERK_AUTH ? (
+                        <CustomNavigate replace to="/organization" />
+                      ) : (
+                        <CustomNavigate replace to="flows" />
+                      )
+                    }
+                  />
+                  {ENABLE_FILE_MANAGEMENT && (
+                    <Route
+                      path="files"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <FilesPage />
+                        </Suspense>
+                      }
+                    />
+                  )}
+                  <Route
+                    path="flows/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="flows" type="flows" />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="components/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="components" type="components" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="components" type="components" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                  <Route
+                    path="all/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="flows" type="flows" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="flows" type="flows" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                  <Route
+                    path="mcp/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <HomePage key="mcp" type="mcp" />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <HomePage key="mcp" type="mcp" />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                  <Route
+                    path="flow/:id"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <CustomDashboardWrapperPage />
+                      </Suspense>
+                    }
+                  >
+                    <Route
+                      path="folder/:folderId"
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <FlowPage />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path=""
+                      element={
+                        <Suspense fallback={<LoadingPage />}>
+                          <FlowPage />
+                        </Suspense>
+                      }
+                    />
+                  </Route>
+                </Route>
+                {CustomRoutesStore()}
+                {CustomRoutesStorePages()}
+                <Route path="account">
+                  <Route
+                    path="delete"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <DeleteAccountPage />
+                      </Suspense>
+                    }
+                  />
+                </Route>
+                <Route
+                  path="admin"
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <ProtectedAdminRoute>
+                        <AdminPage />
+                      </ProtectedAdminRoute>
                     </Suspense>
                   }
                 />
               </Route>
-              <Route
-                path="view"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ViewPage />
-                  </Suspense>
-                }
-              />
+              <Route path="flow/:id/">
+                <Route
+                  path=""
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <CustomDashboardWrapperPage />
+                    </Suspense>
+                  }
+                >
+                  <Route
+                    path="folder/:folderId/"
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <FlowPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path=""
+                    element={
+                      <Suspense fallback={<LoadingPage />}>
+                        <FlowPage />
+                      </Suspense>
+                    }
+                  />
+                </Route>
+                <Route
+                  path="view"
+                  element={
+                    <Suspense fallback={<LoadingPage />}>
+                      <ViewPage />
+                    </Suspense>
+                  }
+                />
+              </Route>
             </Route>
           </Route>
         </Route>
-        <Route
-          path="login"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
         <Route
           path="organization"
           element={
             <Suspense fallback={<LoadingPage />}>
               <ProtectedLoginRoute>
                 <OrganizationPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="signup"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <SignUp />
               </ProtectedLoginRoute>
             </Suspense>
           }
@@ -376,8 +334,36 @@ const router = createBrowserRouter(
           }
         />
       </Route>
-      <Route path="*" element={<CustomNavigate replace to="/" />} />
+      <Route
+        index
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <LandingPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="login"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="signup"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <SignUp />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
     </Route>,
+    <Route path="*" element={<CustomNavigate replace to="/" />} />,
   ]),
   { basename: BASENAME || undefined },
 );


### PR DESCRIPTION
## Summary
- add a lightweight `PublicLayout` that only registers the providers needed by public pages
- simplify `AppWrapperPage` to focus on authenticated shell rendering
- redirect authenticated users away from the marketing landing page and route marketing/login/signup through the public layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3a860debc8326820432e8aa71b577