### PR TITLE
Redirect signed-in users from Clerk login

### DIFF
--- a/src/frontend/src/clerk/login-pages.tsx
+++ b/src/frontend/src/clerk/login-pages.tsx
@@ -4,6 +4,17 @@ import { useLogout } from "./auth";
 import { IS_CLERK_AUTH } from "@/clerk/auth";
 // Clerk login page component
 export function ClerkLoginPage() {
+  const { isSignedIn } = useAuth();
+  const navigate = useCustomNavigate();
+  const [processed, setProcessed] = useState(false);
+
+  useEffect(() => {
+    if (isSignedIn && !processed) {
+      setProcessed(true);
+      navigate("/organization");
+    }
+  }, [isSignedIn, navigate, processed]);
+
   return (
     <SignedOut>
       <div style={centeredStyle}>


### PR DESCRIPTION
## Summary
- add a signed-in guard on the Clerk login page to push authenticated users to the organization selection flow

## Testing
- `npx prettier --check src/frontend/src/clerk/login-pages.tsx` *(fails: Cannot find package 'prettier-plugin-organize-imports')*

------
https://chatgpt.com/codex/tasks/task_e_68d3c978f8888326b8eb45e2bcb3ac03