### PR TITLE
Disable client-side health polling

### DIFF
--- a/src/frontend/src/controllers/API/queries/health/use-get-health.ts
+++ b/src/frontend/src/controllers/API/queries/health/use-get-health.ts
@@ -2,7 +2,10 @@ import {
   REFETCH_SERVER_HEALTH_INTERVAL,
   SERVER_HEALTH_INTERVAL,
 } from "@/constants/constants";
-import { HEALTH_CHECK_URL } from "@/customization/config-constants";
+import {
+  ENABLE_CLIENT_HEALTH_CHECK,
+  HEALTH_CHECK_URL,
+} from "@/customization/config-constants";
 import { useUtilityStore } from "@/stores/utilityStore";
 import { createNewError503 } from "@/types/factory/axios-error-503";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -40,6 +43,17 @@ export const useGetHealthQuery: useQueryFunctionType<
    * @returns {Promise<AxiosResponse<TransactionsResponse>>} A promise that resolves to an AxiosResponse containing the health status.
    */
   async function getHealthFn() {
+    if (!ENABLE_CLIENT_HEALTH_CHECK) {
+      setHealthCheckTimeout(null);
+      return {
+        status: "ok",
+        chat: "ok",
+        db: "ok",
+        folder: "ok",
+        variables: "ok",
+      } satisfies getHealthResponse;
+    }
+
     try {
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(createNewError503()), SERVER_HEALTH_INTERVAL),

--- a/src/frontend/src/customization/config-constants.ts
+++ b/src/frontend/src/customization/config-constants.ts
@@ -5,6 +5,7 @@ export const API_ROUTES = ["^/api/v1/", "^/api/v2/", "/health"];
 export const BASE_URL_API = "/api/v1/";
 export const BASE_URL_API_V2 = "/api/v2/";
 export const HEALTH_CHECK_URL = "/health_check";
+export const ENABLE_CLIENT_HEALTH_CHECK = false;
 export const DOCS_LINK = "https://docs.langflow.org";
 
 export default {
@@ -16,4 +17,5 @@ export default {
   BASE_URL_API,
   BASE_URL_API_V2,
   HEALTH_CHECK_URL,
+  ENABLE_CLIENT_HEALTH_CHECK,
 };


### PR DESCRIPTION
## Summary
- add a customization flag to disable the frontend health check endpoint call
- short-circuit the health query when client health polling is disabled so the browser never hits /health_check

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d501a8b3a4832682f5415f81397c37