### PR TITLE
Avoid redirect after logout

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -27,9 +27,8 @@ export default function OrganizationSwitcherPage() {
   const [isBootstrapping, setIsBootstrapping] = useState(false);
 
   useEffect(() => {
-    if (!organization?.id || !isOrgSelectedManually || bootstrapped.current) {
+    if (!organization?.id || !isOrgSelectedManually || bootstrapped.current)
       return;
-    }
 
     bootstrapped.current = true;
     setIsBootstrapping(true);

--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -1,10 +1,16 @@
-import { OrganizationList, useAuth, useOrganization, useUser } from "@clerk/clerk-react";
-import { useContext, useEffect, useRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { ensureLangflowUser, createOrganisation, backendLogin } from "./auth";
-import authStore from "@/stores/authStore";
 import { useLogout } from "@/clerk/auth";
 import { AuthContext } from "@/contexts/authContext";
+import { LoadingPage } from "@/pages/LoadingPage";
+import authStore from "@/stores/authStore";
+import {
+  OrganizationList,
+  useAuth,
+  useOrganization,
+  useUser,
+} from "@clerk/clerk-react";
+import { useContext, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { backendLogin, createOrganisation, ensureLangflowUser } from "./auth";
 
 export default function OrganizationSwitcherPage() {
   const { getToken } = useAuth();
@@ -18,11 +24,15 @@ export default function OrganizationSwitcherPage() {
   const justLoggedIn = useRef(false);
   const searchParams = new URLSearchParams(location.search);
   const isOrgSelectedManually = searchParams.get("selected") === "true";
+  const [isBootstrapping, setIsBootstrapping] = useState(false);
 
-useEffect(() => {
-  if (!organization?.id || !isOrgSelectedManually || bootstrapped.current) return;
+  useEffect(() => {
+    if (!organization?.id || !isOrgSelectedManually || bootstrapped.current) {
+      return;
+    }
 
     bootstrapped.current = true;
+    setIsBootstrapping(true);
 
     (async () => {
       console.log("[OrgSwitcherPage] Starting bootstrap flow...");
@@ -35,12 +45,12 @@ useEffect(() => {
         user?.primaryEmailAddress?.emailAddress ||
         user?.id ||
         "clerk_user";
-      try{
+      try {
         // Step 1: Create backend organization (DB provisioning or linking)
         console.debug("[OrgSwitcherPage] Calling createOrganisation()");
         await createOrganisation(orgToken);
         console.debug("[OrgSwitcherPage] createOrganisation() completed");
-  
+
         // Step 2: Ensure Langflow user exists via /whoami or /users
         console.debug("[OrgSwitcherPage] Calling ensureLangflowUser()");
         await ensureLangflowUser(orgToken, username);
@@ -48,32 +58,50 @@ useEffect(() => {
         console.debug("[OrgSwitcherPage] Calling backendLogin()");
         const tokens = await backendLogin(username, orgToken);
         console.debug("[OrgSwitcherPage] backendLogin() succeeded");
-  
+
         // Step 4: Save access & refresh tokens into store and cookies
         login(orgToken, "login", tokens.refresh_token);
         justLoggedIn.current = true;
-  
+
         // Step 5: Only now mark org as selected
         authStore.getState().setIsOrgSelected(true);
         sessionStorage.setItem("isOrgSelected", "true");
         console.debug("[OrgSwitcherPage] Org selection state marked");
-  
+
         // Step 6: Navigate to /flows
         console.debug("[OrgSwitcherPage] Redirecting to /flows");
         navigate("/flows", { replace: true });
-      }catch(err){
-        if(!justLoggedIn.current){
+      } catch (err) {
+        if (!justLoggedIn.current) {
           console.error("[OrgSwitcherPage] Error during bootstrap", err);
           await logout();
-        }else{
-          console.warn("[OrgSwitcherPage] Ignoring error after successful login", err);
+        } else {
+          console.warn(
+            "[OrgSwitcherPage] Ignoring error after successful login",
+            err,
+          );
         }
+      } finally {
+        setIsBootstrapping(false);
       }
     })().catch((err) => {
       console.error("[OrgSwitcherPage] Bootstrap failed", err);
       bootstrapped.current = false;
+      setIsBootstrapping(false);
     });
-  }, [organization?.id, isOrgSelectedManually, getToken, user, navigate]);
+  }, [
+    organization?.id,
+    isOrgSelectedManually,
+    getToken,
+    user,
+    navigate,
+    login,
+    logout,
+  ]);
+
+  if (isOrgSelectedManually || isBootstrapping) {
+    return <LoadingPage />;
+  }
 
   return (
     <div

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { Suspense, lazy } from "react";
 import {
   createBrowserRouter,
   createRoutesFromElements,
@@ -47,9 +47,7 @@ const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const GlobalVariablesPage = lazy(
   () => import("./pages/SettingsPage/pages/GlobalVariablesPage"),
 );
-const ApiKeysPage = lazy(
-  () => import("./pages/SettingsPage/pages/ApiKeysPage"),
-);
+const ApiKeysPage = lazy(() => import("./pages/SettingsPage/pages/ApiKeysPage"));
 const GeneralPage = lazy(
   () => import("./pages/SettingsPage/pages/GeneralPage"),
 );
@@ -224,10 +222,7 @@ const router = createBrowserRouter(
                   </Suspense>
                 }
               >
-                <Route
-                  index
-                  element={<CustomNavigate replace to="general" />}
-                />
+                <Route index element={<CustomNavigate replace to="general" />} />
                 <Route
                   path="global-variables"
                   element={

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -5,7 +5,6 @@ import {
   Outlet,
   Route,
 } from "react-router-dom";
-import { IS_CLERK_AUTH } from "./clerk/auth";
 import { ProtectedAdminRoute } from "./components/authorization/authAdminGuard";
 import { ProtectedRoute } from "./components/authorization/authGuard";
 import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
@@ -20,7 +19,7 @@ import {
 import { CustomRoutesStore } from "./customization/utils/custom-routes-store";
 import { CustomRoutesStorePages } from "./customization/utils/custom-routes-store-pages";
 import { LoadingPage } from "./pages/LoadingPage";
-import authStore from "./stores/authStore";
+import { CollectionIndexRedirect } from "./routes/CollectionIndexRedirect";
 
 const AppWrapperPage = lazy(() =>
   import("./pages/AppWrapperPage").then((module) => ({
@@ -81,28 +80,6 @@ const LoginAdminPage = lazy(() =>
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 const PlaygroundPage = lazy(() => import("./pages/Playground"));
-
-const isOrganizationSelected = () => {
-  if (authStore.getState().isOrgSelected) {
-    return true;
-  }
-
-  if (typeof window !== "undefined") {
-    return sessionStorage.getItem("isOrgSelected") === "true";
-  }
-
-  return false;
-};
-
-const CollectionIndexRedirect = () => {
-  const { isAuthenticated } = authStore.getState();
-
-  if (IS_CLERK_AUTH && isAuthenticated && !isOrganizationSelected()) {
-    return <CustomNavigate replace to="/organization" />;
-  }
-
-  return <CustomNavigate replace to="flows" />;
-};
 
 const router = createBrowserRouter(
   createRoutesFromElements([

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -1,10 +1,11 @@
-import { Suspense, lazy } from "react";
+import { lazy, Suspense } from "react";
 import {
   createBrowserRouter,
   createRoutesFromElements,
   Outlet,
   Route,
 } from "react-router-dom";
+import { IS_CLERK_AUTH } from "./clerk/auth";
 import { ProtectedAdminRoute } from "./components/authorization/authAdminGuard";
 import { ProtectedRoute } from "./components/authorization/authGuard";
 import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
@@ -18,8 +19,8 @@ import {
 } from "./customization/feature-flags";
 import { CustomRoutesStore } from "./customization/utils/custom-routes-store";
 import { CustomRoutesStorePages } from "./customization/utils/custom-routes-store-pages";
-import { IS_CLERK_AUTH } from "./clerk/auth";
 import { LoadingPage } from "./pages/LoadingPage";
+import authStore from "./stores/authStore";
 
 const AppWrapperPage = lazy(() =>
   import("./pages/AppWrapperPage").then((module) => ({
@@ -47,7 +48,9 @@ const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const GlobalVariablesPage = lazy(
   () => import("./pages/SettingsPage/pages/GlobalVariablesPage"),
 );
-const ApiKeysPage = lazy(() => import("./pages/SettingsPage/pages/ApiKeysPage"));
+const ApiKeysPage = lazy(
+  () => import("./pages/SettingsPage/pages/ApiKeysPage"),
+);
 const GeneralPage = lazy(
   () => import("./pages/SettingsPage/pages/GeneralPage"),
 );
@@ -78,6 +81,28 @@ const LoginAdminPage = lazy(() =>
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 const PlaygroundPage = lazy(() => import("./pages/Playground"));
+
+const isOrganizationSelected = () => {
+  if (authStore.getState().isOrgSelected) {
+    return true;
+  }
+
+  if (typeof window !== "undefined") {
+    return sessionStorage.getItem("isOrgSelected") === "true";
+  }
+
+  return false;
+};
+
+const CollectionIndexRedirect = () => {
+  const { isAuthenticated } = authStore.getState();
+
+  if (IS_CLERK_AUTH && isAuthenticated && !isOrganizationSelected()) {
+    return <CustomNavigate replace to="/organization" />;
+  }
+
+  return <CustomNavigate replace to="flows" />;
+};
 
 const router = createBrowserRouter(
   createRoutesFromElements([
@@ -143,16 +168,7 @@ const router = createBrowserRouter(
                   </Suspense>
                 }
               >
-                <Route
-                  index
-                  element={
-                    IS_CLERK_AUTH ? (
-                      <CustomNavigate replace to="/organization" />
-                    ) : (
-                      <CustomNavigate replace to="flows" />
-                    )
-                  }
-                />
+                <Route index element={<CollectionIndexRedirect />} />
                 {ENABLE_FILE_MANAGEMENT && (
                   <Route
                     path="files"
@@ -231,7 +247,10 @@ const router = createBrowserRouter(
                   </Suspense>
                 }
               >
-                <Route index element={<CustomNavigate replace to="general" />} />
+                <Route
+                  index
+                  element={<CustomNavigate replace to="general" />}
+                />
                 <Route
                   path="global-variables"
                   element={

--- a/src/frontend/src/routes/CollectionIndexRedirect.tsx
+++ b/src/frontend/src/routes/CollectionIndexRedirect.tsx
@@ -1,0 +1,25 @@
+import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { CustomNavigate } from "@/customization/components/custom-navigate";
+import authStore from "@/stores/authStore";
+
+const isOrganizationSelected = () => {
+  if (authStore.getState().isOrgSelected) {
+    return true;
+  }
+
+  if (typeof window !== "undefined") {
+    return sessionStorage.getItem("isOrgSelected") === "true";
+  }
+
+  return false;
+};
+
+export function CollectionIndexRedirect() {
+  const { isAuthenticated } = authStore.getState();
+
+  if (IS_CLERK_AUTH && isAuthenticated && !isOrganizationSelected()) {
+    return <CustomNavigate replace to="/organization" />;
+  }
+
+  return <CustomNavigate replace to="flows" />;
+}

--- a/src/frontend/src/routes/CollectionIndexRedirect.tsx
+++ b/src/frontend/src/routes/CollectionIndexRedirect.tsx
@@ -2,22 +2,21 @@ import { IS_CLERK_AUTH } from "@/clerk/auth";
 import { CustomNavigate } from "@/customization/components/custom-navigate";
 import authStore from "@/stores/authStore";
 
-const isOrganizationSelected = () => {
-  if (authStore.getState().isOrgSelected) {
-    return true;
-  }
-
-  if (typeof window !== "undefined") {
-    return sessionStorage.getItem("isOrgSelected") === "true";
-  }
-
-  return false;
-};
+const hasSelectedOrganization = () =>
+  typeof window !== "undefined" &&
+  sessionStorage.getItem("isOrgSelected") === "true";
 
 export function CollectionIndexRedirect() {
-  const { isAuthenticated } = authStore.getState();
+  const { isAuthenticated, isOrgSelected } = authStore((state) => ({
+    isAuthenticated: state.isAuthenticated,
+    isOrgSelected: state.isOrgSelected,
+  }));
 
-  if (IS_CLERK_AUTH && isAuthenticated && !isOrganizationSelected()) {
+  const organizationChosen =
+    Boolean(isOrgSelected) ||
+    (IS_CLERK_AUTH && hasSelectedOrganization());
+
+  if (IS_CLERK_AUTH && isAuthenticated && !organizationChosen) {
     return <CustomNavigate replace to="/organization" />;
   }
 


### PR DESCRIPTION
## Summary
- only redirect the collection index to the organization picker when the user is authenticated

## Testing
- npx prettier --check src/routes.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d53551fea48326afdcfe2894822a33