### PR TITLE
Split landing experience into dedicated UI app

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -160,6 +160,16 @@ You will get output similar to:
 
 At this point, you can navigate to http://localhost:3000/ in a browser and access the Langflow User Interface.
 
+If you only need to work on the lean landing/authentication experience, a dedicated Vite server is available:
+
+```bash
+cd src/frontend
+npm run start:landing
+```
+
+This entry point serves the marketing, login, sign-up, and organization-selection flows without loading the heavier flow builder bundles. Use `npm run start:flows` (the default `npm start`) for the full flow builder UI.
+
+
 ### Build and Display Documentation
 
 If you are contributing changes to documentation (always welcome!), these are built (using [Docusaurus](https://docusaurus.io/)) and served separately, also using Node.js.

--- a/src/frontend/landing/index.html
+++ b/src/frontend/landing/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <base href="/" />
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon-new.ico" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chivo:ital,wght@0,100..900;1,100..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+      rel="stylesheet"
+    />
+    <title>Langflow – Welcome</title>
+  </head>
+  <body id="body" class="dark" style="width: 100%; height: 100%">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div style="width: 100vw; height: 100vh" id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/frontend/landing/src/main.tsx
+++ b/src/frontend/landing/src/main.tsx
@@ -1,0 +1,1 @@
+import "../../src/landing/index.tsx";

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -92,12 +92,21 @@
   },
   "scripts": {
     "dev:docker": "vite --host 0.0.0.0",
-    "start": "vite",
-    "build": "vite build",
+    "start": "npm run start:flows",
+    "build": "npm run build:flows",
     "serve": "vite preview",
     "format": "npx prettier --write \"{tests,src}/**/*.{js,jsx,ts,tsx,json,md}\" --ignore-path .prettierignore",
     "check-format": "npx prettier --check \"{tests,src}/**/*.{js,jsx,ts,tsx,json,md}\" --ignore-path .prettierignore",
-    "type-check": "tsc --noEmit --pretty --project tsconfig.json && vite"
+    "type-check": "tsc --noEmit --pretty --project tsconfig.json && vite",
+    "start:flows": "vite",
+    "start:landing": "vite --config vite.config.landing.mts",
+    "dev:flows": "vite --config vite.config.mts --host 0.0.0.0",
+    "dev:landing": "vite --config vite.config.landing.mts --host 0.0.0.0",
+    "build:flows": "vite build --config vite.config.mts",
+    "build:landing": "vite build --config vite.config.landing.mts",
+    "build:all": "npm run build:landing && npm run build:flows",
+    "preview:landing": "vite preview --config vite.config.landing.mts",
+    "preview:flows": "vite preview --config vite.config.mts"
   },
   "eslintConfig": {
     "extends": [

--- a/src/frontend/src/components/authorization/authLoginGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authLoginGuard/index.tsx
@@ -9,12 +9,8 @@ export const ProtectedLoginRoute = ({ children }) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const location = useLocation();
 
-  // // ✅ Only enforce this wrapper on the actual login page
-  // const isLoginPage = location.pathname.includes("login");
-  // if (!isLoginPage) return children;
-
   let organizationId: string | undefined = undefined;
-  let isOrgLoaded = true; // default true if not using Clerk
+  let isOrgLoaded = true;
 
   if (IS_CLERK_AUTH) {
     const { organization, isLoaded } = useOrganization();
@@ -22,10 +18,9 @@ export const ProtectedLoginRoute = ({ children }) => {
     isOrgLoaded = isLoaded;
   }
 
-    // ✅ Only enforce this wrapper on the actual login page
   const isLoginPage = location.pathname.includes("login");
   if (!isLoginPage) return children;
-  
+
   const isOrgSelected = IS_CLERK_AUTH ? !!organizationId : true;
 
   const canRedirect =
@@ -40,7 +35,7 @@ export const ProtectedLoginRoute = ({ children }) => {
     if (redirectPath) {
       return <CustomNavigate to={redirectPath} replace />;
     }
-    return <CustomNavigate to="/home" replace />;
+    return <CustomNavigate to="/flows" replace />;
   }
   return children;
 };

--- a/src/frontend/src/landing/LandingApp.tsx
+++ b/src/frontend/src/landing/LandingApp.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { RouterProvider } from "react-router-dom";
+
+import { LoadingPage } from "@/pages/LoadingPage";
+import { landingRouter } from "./landing-router";
+
+export function LandingApp() {
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <RouterProvider router={landingRouter} />
+    </Suspense>
+  );
+}

--- a/src/frontend/src/landing/index.tsx
+++ b/src/frontend/src/landing/index.tsx
@@ -1,0 +1,18 @@
+import ReactDOM from "react-dom/client";
+
+import "../style/classes.css";
+import "../style/index.css";
+import "../style/applies.css";
+
+import AppWithProvider from "@/clerk/auth";
+import { LandingApp } from "./LandingApp";
+
+const root = ReactDOM.createRoot(
+  document.getElementById("root") as HTMLElement,
+);
+
+root.render(
+  <AppWithProvider>
+    <LandingApp />
+  </AppWithProvider>,
+);

--- a/src/frontend/src/landing/landing-api-interceptor.tsx
+++ b/src/frontend/src/landing/landing-api-interceptor.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo } from "react";
+import { AxiosError } from "axios";
+import * as fetchIntercept from "fetch-intercept";
+
+import { useLogout } from "@/clerk/auth";
+import { useCustomApiHeaders } from "@/customization/hooks/use-custom-api-headers";
+import { customGetAccessToken } from "@/customization/utils/custom-get-access-token";
+import { api } from "@/controllers/API/api";
+
+function isExternalURL(url: string): boolean {
+  const EXTERNAL_DOMAINS = [
+    "https://raw.githubusercontent.com",
+    "https://api.github.com",
+    "https://api.segment.io",
+    "https://cdn.sprig.com",
+  ];
+
+  try {
+    const parsedURL = new URL(url);
+    return EXTERNAL_DOMAINS.some((domain) => parsedURL.origin === domain);
+  } catch (e) {
+    return false;
+  }
+}
+
+export function LandingApiInterceptor() {
+  const customHeaders = useCustomApiHeaders();
+  const serializedHeaders = useMemo(
+    () => JSON.stringify(customHeaders ?? {}),
+    [customHeaders],
+  );
+  const { mutate: triggerLogout } = useLogout();
+
+  useEffect(() => {
+    const unregister = fetchIntercept.register({
+      request: function (url, config: any) {
+        const accessToken = customGetAccessToken();
+
+        config.headers = config.headers ?? {};
+
+        if (accessToken && !config.headers["Authorization"]) {
+          config.headers["Authorization"] = `Bearer ${accessToken}`;
+        }
+
+        if (!isExternalURL(url)) {
+          const parsedHeaders = JSON.parse(serializedHeaders) as Record<string, string>;
+          for (const [key, value] of Object.entries(parsedHeaders)) {
+            config.headers[key] = value;
+          }
+        }
+
+        return [url, config];
+      },
+    });
+
+    const requestInterceptor = api.interceptors.request.use((config) => {
+      const token = customGetAccessToken();
+
+      config.headers = config.headers ?? {};
+
+      if (token && !config.headers["Authorization"]) {
+        config.headers["Authorization"] = `Bearer ${token}`;
+      }
+
+      if (config.url && !isExternalURL(config.url)) {
+        const parsedHeaders = JSON.parse(serializedHeaders) as Record<string, string>;
+        for (const [key, value] of Object.entries(parsedHeaders)) {
+          config.headers[key] = value;
+        }
+      }
+
+      return config;
+    });
+
+    const responseInterceptor = api.interceptors.response.use(
+      (response) => response,
+      async (error: AxiosError) => {
+        const status = error?.response?.status;
+
+        if (status === 401 || status === 403) {
+          triggerLogout();
+        }
+
+        return Promise.reject(error);
+      },
+    );
+
+    return () => {
+      unregister();
+      api.interceptors.request.eject(requestInterceptor);
+      api.interceptors.response.eject(responseInterceptor);
+    };
+  }, [serializedHeaders, triggerLogout]);
+
+  return null;
+}

--- a/src/frontend/src/landing/landing-context-wrapper.tsx
+++ b/src/frontend/src/landing/landing-context-wrapper.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren, useRef } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { GradientWrapper } from "@/components/common/GradientWrapper";
+import { ClerkAuthAdapter, IS_CLERK_AUTH } from "@/clerk/auth";
+import { CustomWrapper } from "@/customization/custom-wrapper";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { AuthProvider } from "@/contexts/authContext";
+import { LandingApiInterceptor } from "./landing-api-interceptor";
+
+export function LandingContextWrapper({ children }: PropsWithChildren) {
+  const queryClientRef = useRef<QueryClient>();
+
+  if (!queryClientRef.current) {
+    queryClientRef.current = new QueryClient();
+  }
+
+  return (
+    <CustomWrapper>
+      <GradientWrapper>
+        <QueryClientProvider client={queryClientRef.current}>
+          <AuthProvider>
+            {IS_CLERK_AUTH && <ClerkAuthAdapter />}
+            <TooltipProvider skipDelayDuration={0}>
+              <LandingApiInterceptor />
+              {children}
+            </TooltipProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </GradientWrapper>
+    </CustomWrapper>
+  );
+}

--- a/src/frontend/src/landing/landing-router.tsx
+++ b/src/frontend/src/landing/landing-router.tsx
@@ -1,0 +1,66 @@
+import { Suspense, lazy } from "react";
+import {
+  Outlet,
+  Route,
+  createBrowserRouter,
+  createRoutesFromElements,
+} from "react-router-dom";
+
+import { ProtectedRoute } from "@/components/authorization/authGuard";
+import { ProtectedLoginRoute } from "@/components/authorization/authLoginGuard";
+import { BASENAME } from "@/customization/config-constants";
+import { LandingContextWrapper } from "./landing-context-wrapper";
+import { LoadingPage } from "@/pages/LoadingPage";
+
+const LandingPage = lazy(() =>
+  import("@/pages/LandingPage").then((module) => ({
+    default: module.default,
+  })),
+);
+const LoginPage = lazy(() =>
+  import("@/clerk/login-pages").then((module) => ({
+    default: module.LoginPage,
+  })),
+);
+const SignUpPage = lazy(() =>
+  import("@/clerk/login-pages").then((module) => ({
+    default: module.SignUp,
+  })),
+);
+const OrganizationPage = lazy(() => import("@/clerk/OrganizationPage"));
+const LogoutPage = lazy(() => import("./pages/LogoutPage"));
+
+const LandingLayout = () => (
+  <LandingContextWrapper>
+    <Suspense fallback={<LoadingPage />}>
+      <Outlet />
+    </Suspense>
+  </LandingContextWrapper>
+);
+
+export const landingRouter = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path="/" element={<LandingLayout />}>
+      <Route index element={<LandingPage />} />
+      <Route
+        path="login"
+        element={
+          <ProtectedLoginRoute>
+            <LoginPage />
+          </ProtectedLoginRoute>
+        }
+      />
+      <Route path="sign-up" element={<SignUpPage />} />
+      <Route
+        path="organization"
+        element={
+          <ProtectedRoute>
+            <OrganizationPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="logout" element={<LogoutPage />} />
+    </Route>,
+  ),
+  { basename: BASENAME || "" },
+);

--- a/src/frontend/src/landing/pages/LogoutPage.tsx
+++ b/src/frontend/src/landing/pages/LogoutPage.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+import { useLogout } from "@/clerk/auth";
+import { LoadingPage } from "@/pages/LoadingPage";
+import { CustomNavigate } from "@/customization/components/custom-navigate";
+
+export default function LogoutPage() {
+  const { mutate, isSuccess } = useLogout({
+    onSuccess: () => {
+      sessionStorage.removeItem("isOrgSelected");
+    },
+  });
+
+  useEffect(() => {
+    mutate();
+  }, [mutate]);
+
+  if (isSuccess) {
+    return <CustomNavigate to="/login" replace />;
+  }
+
+  return <LoadingPage />;
+}

--- a/src/frontend/vite.config.landing.mts
+++ b/src/frontend/vite.config.landing.mts
@@ -1,0 +1,75 @@
+import react from "@vitejs/plugin-react-swc";
+import * as dotenv from "dotenv";
+import path from "path";
+import { defineConfig, loadEnv } from "vite";
+import svgr from "vite-plugin-svgr";
+import tsconfigPaths from "vite-tsconfig-paths";
+import {
+  API_ROUTES,
+  BASENAME,
+  PORT,
+  PROXY_TARGET,
+} from "./src/customization/config-constants";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  const envLangflowResult = dotenv.config({
+    path: path.resolve(__dirname, "../../.env"),
+  });
+
+  const envLangflow = envLangflowResult.parsed || {};
+
+  const apiRoutes = API_ROUTES || ["^/api/v1/", "^/api/v2/", "/health"];
+
+  const target =
+    env.VITE_PROXY_TARGET || PROXY_TARGET || "http://127.0.0.1:7860";
+
+  const port = Number(env.VITE_PORT) || PORT || 3000;
+
+  const proxyTargets = apiRoutes.reduce((proxyObj, route) => {
+    proxyObj[route] = {
+      target: target,
+      changeOrigin: true,
+      secure: false,
+      ws: true,
+    };
+    return proxyObj;
+  }, {} as Record<string, any>);
+
+  return {
+    base: BASENAME || "",
+    root: path.resolve(__dirname, "landing"),
+    publicDir: path.resolve(__dirname, "public"),
+    build: {
+      outDir: path.resolve(__dirname, "build-landing"),
+      emptyOutDir: true,
+    },
+    define: {
+      "process.env.BACKEND_URL": JSON.stringify(
+        envLangflow.BACKEND_URL ?? "http://127.0.0.1:7860",
+      ),
+      "process.env.ACCESS_TOKEN_EXPIRE_SECONDS": JSON.stringify(
+        envLangflow.ACCESS_TOKEN_EXPIRE_SECONDS ?? 60,
+      ),
+      "process.env.CI": JSON.stringify(envLangflow.CI ?? false),
+      "process.env.LANGFLOW_AUTO_LOGIN": JSON.stringify(
+        envLangflow.LANGFLOW_AUTO_LOGIN ?? true,
+      ),
+    },
+    plugins: [react(), svgr(), tsconfigPaths()],
+    server: {
+      port: port,
+      proxy: {
+        ...proxyTargets,
+      },
+      fs: {
+        allow: [
+          path.resolve(__dirname, 'landing'),
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, '..'),
+        ],
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add a dedicated landing/auth front-end entry point with its own router, context wrapper, and logout flow
- introduce a lightweight landing API interceptor plus HTML/bootstrap assets and a Vite config for the new app
- update npm scripts, docs, and login redirect defaults so landing and flow servers can be run independently

## Testing
- CI=1 npm run build:landing > /tmp/build_landing.log
- CI=1 npm run build:flows > /tmp/build_flows.log

------
https://chatgpt.com/codex/tasks/task_e_68d65cd2cda8832686c2fab89a46194d