### PR TITLE
Defer app bundle until navigating beyond landing page

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,4 +1,6 @@
-import "@xyflow/react/dist/style.css";
+// NOTE: The react-flow stylesheet is now imported on demand in the FlowPage.
+// Importing it here caused the Flow builder styles to be bundled into the
+// landing-page chunk, so we remove it from the root app component.
 import { Suspense, useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { LoadingPage } from "./pages/LoadingPage";

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,25 +1,43 @@
 import ReactDOM from "react-dom/client";
+import { Suspense, lazy } from "react";
 import reportWebVitals from "./reportWebVitals";
 
 import "./style/classes.css";
 // @ts-ignore
 import "./style/index.css";
 // @ts-ignore
-import "./App.css";
 import "./style/applies.css";
 
-// @ts-ignore
+// Load the marketing landing page and loading spinner synchronously.
+import LandingPage from "./pages/LandingPage";
+import { LoadingPage } from "./pages/LoadingPage";
 
-import AppWithProvider from "./clerk/auth";
-import CustomApp from "./customization/custom-App";
-
+// Create the root element once.
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
-root.render(
-  <AppWithProvider>
-    <CustomApp />
-  </AppWithProvider>,
-);
+// If the visitor is on the root path, render only the landing page without
+// pulling in the full app bundle. Otherwise, defer loading heavy modules
+// until needed using React.lazy and Suspense.
+if (
+  window.location.pathname === "/" ||
+  window.location.pathname === "/index.html"
+) {
+  root.render(<LandingPage />);
+} else {
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((module) => ({ default: module.default })),
+  );
+  const CustomApp = lazy(() => import("./customization/custom-App"));
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <CustomApp />
+      </AppWithProvider>
+    </Suspense>,
+  );
+}
+
+// Continue reporting web vitals for both the landing page and the app.
 reportWebVitals();

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -1,3 +1,6 @@
+// Pull in the react-flow stylesheet here so it is only loaded when the FlowPage
+// is rendered. This prevents the landing page from loading unnecessary CSS.
+import "@xyflow/react/dist/style.css";
 import { DefaultEdge } from "@/CustomEdges";
 import NoteNode from "@/CustomNodes/NoteNode";
 import FlowToolbar from "@/components/core/flowToolbarComponent";


### PR DESCRIPTION
## Summary
- lazy load the authenticated app bundle unless the visitor navigates away from the landing page
- load the marketing landing page and spinner synchronously for instant render while keeping web vitals reporting
- scope the react-flow stylesheet to the FlowPage so the landing chunk avoids unnecessary CSS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d771adab58832696dd04ffd21e522c