### PR TITLE
Refine frontend lazy loading for auth routes

### DIFF
--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,4 +1,6 @@
+import { Suspense, lazy } from "react";
 import ReactDOM from "react-dom/client";
+
 import reportWebVitals from "./reportWebVitals";
 
 import "./style/classes.css";
@@ -9,17 +11,93 @@ import "./App.css";
 import "./style/applies.css";
 
 // @ts-ignore
-
-import AppWithProvider from "./clerk/auth";
-import CustomApp from "./customization/custom-App";
+import LandingPage from "./pages/LandingPage";
+import { LoadingPage } from "./pages/LoadingPage";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
-root.render(
-  <AppWithProvider>
-    <CustomApp />
-  </AppWithProvider>,
-);
+// Route to specific pages based on the current pathname.  This ensures that
+// authentication pages (login, signup, admin login, organization selection)
+// load only their own code and avoid pulling in the full application bundle.
+const pathname = window.location.pathname;
+if (pathname === "/" || pathname === "/index.html") {
+  // Landing page: no heavy modules required
+  root.render(<LandingPage />);
+} else if (pathname === "/login" || pathname === "/login/") {
+  // Email/password login page
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((m) => ({ default: m.default })),
+  );
+  const LoginPage = lazy(() =>
+    import("./clerk/login-pages").then((m) => ({ default: m.LoginPage })),
+  );
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <LoginPage />
+      </AppWithProvider>
+    </Suspense>,
+  );
+} else if (pathname === "/signup" || pathname === "/signup/") {
+  // Sign-up page
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((m) => ({ default: m.default })),
+  );
+  const SignUpPage = lazy(() =>
+    import("./clerk/login-pages").then((m) => ({ default: m.SignUp })),
+  );
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <SignUpPage />
+      </AppWithProvider>
+    </Suspense>,
+  );
+} else if (pathname === "/login/admin" || pathname === "/login/admin/") {
+  // Admin login page
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((m) => ({ default: m.default })),
+  );
+  const LoginAdminPage = lazy(() =>
+    import("./clerk/login-pages").then((m) => ({ default: m.LoginAdminPage })),
+  );
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <LoginAdminPage />
+      </AppWithProvider>
+    </Suspense>,
+  );
+} else if (pathname === "/organization" || pathname === "/organization/") {
+  // Organization selection page
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((m) => ({ default: m.default })),
+  );
+  const OrganizationPage = lazy(() =>
+    import("./clerk/OrganizationPage").then((m) => ({ default: m.default })),
+  );
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <OrganizationPage />
+      </AppWithProvider>
+    </Suspense>,
+  );
+} else {
+  // All other pages: load the full application with router/flows etc.
+  const AppWithProvider = lazy(() =>
+    import("./clerk/auth").then((m) => ({ default: m.default })),
+  );
+  const CustomApp = lazy(() => import("./customization/custom-App"));
+  root.render(
+    <Suspense fallback={<LoadingPage />}>
+      <AppWithProvider>
+        <CustomApp />
+      </AppWithProvider>
+    </Suspense>,
+  );
+}
+
 reportWebVitals();


### PR DESCRIPTION
## Summary
- render the landing page without pulling in the application bundle
- lazily load auth wrapper and route-specific components for login, signup, admin login, and organization pages
- keep other paths loading the full customized app behind a suspense fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d774416d408326a638cc3058b0a3ac