### PR TITLE
Optimize landing page bundle by lazy-loading flow styles

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,4 +1,8 @@
-import "@xyflow/react/dist/style.css";
+// React-Flow styles are imported in FlowPage instead of globally, so that
+// they aren't included in the landing bundle.
+
+// Import application-wide styles (Tailwind base/components/utilities).
+import "./App.css";
 import { Suspense, useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { LoadingPage } from "./pages/LoadingPage";

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -3,11 +3,12 @@ import ReactDOM from "react-dom/client";
 
 import reportWebVitals from "./reportWebVitals";
 
+// Import only the minimal styles needed for the landing page.  We avoid
+// importing App.css here because it brings in Tailwind base/components for
+// the flow builder and other authenticated pages.  These styles are now
+// loaded in App.tsx, so they aren't included in the landing-page bundle.
 import "./style/classes.css";
-// @ts-ignore
 import "./style/index.css";
-// @ts-ignore
-import "./App.css";
 import "./style/applies.css";
 
 // @ts-ignore

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -1,3 +1,7 @@
+// Import React-Flow styles here so they're loaded only when the flow
+// builder is rendered.
+import "@xyflow/react/dist/style.css";
+
 import { DefaultEdge } from "@/CustomEdges";
 import NoteNode from "@/CustomNodes/NoteNode";
 import FlowToolbar from "@/components/core/flowToolbarComponent";

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -41,6 +41,27 @@ export default defineConfig(({ mode }) => {
     base: BASENAME || "",
     build: {
       outDir: "build",
+      // Disable modulePreload so that Vite does not prefetch lazily imported
+      // chunks.  Without this, heavy modules (react-flow, ace, ag-grid, etc.)
+      // are downloaded on the landing page.
+      modulePreload: false,
+      rollupOptions: {
+        output: {
+          // Split heavy libraries used only on the flow or admin pages into
+          // their own chunk.  These chunks will load only when those pages
+          // are visited.
+          manualChunks(id) {
+            if (
+              id.includes("@xyflow") ||
+              id.includes("ace-builds") ||
+              id.includes("ag-grid-react") ||
+              id.includes("react-pdf")
+            ) {
+              return "flow-libs";
+            }
+          },
+        },
+      },
     },
     define: {
       "process.env.BACKEND_URL": JSON.stringify(


### PR DESCRIPTION
## Summary
- stop importing the Tailwind app styles in the landing entrypoint and load them inside App instead
- move the React Flow stylesheet to the Flow builder component so the landing bundle stays light
- tune Vite build to disable module preload and isolate heavy flow/admin libraries into their own chunk

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78714cd688326b2bdc4929d72ba9a