### PR TITLE
Fix Clerk login loop when Clerk tokens are cached

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -36,7 +36,7 @@ export default function OrganizationSwitcherPage() {
     (async () => {
       console.log("[OrgSwitcherPage] Starting bootstrap flow...");
 
-      const orgToken = await getToken();
+      const orgToken = await getToken({ skipCache: true });
       if (!orgToken) throw new Error("Missing Clerk org token");
 
       const username =

--- a/src/frontend/src/clerk/auth.tsx
+++ b/src/frontend/src/clerk/auth.tsx
@@ -141,7 +141,7 @@ export function ClerkAuthAdapter() {
   useEffect(() => {
     const unsubscribe = clerk.addListener(async ({ session }) => {
       console.debug("[ClerkAuthAdapter] Token update event received");
-      const token = await session?.getToken();
+      const token = await session?.getToken({ skipCache: true });
       const orgSelected = sessionStorage.getItem("isOrgSelected") === "true";
 
       if (!orgSelected) {


### PR DESCRIPTION
## Summary
- ensure the organization bootstrap flow fetches a fresh Clerk token after selection so the backend sees the active organization
- update the Clerk auth listener to always request an uncached Clerk session token before syncing with the backend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7ca08fb88326b2160e00b98d5ac8