### PR TITLE
Display organization info in header

### DIFF
--- a/src/frontend/src/components/common/organizationDisplay/index.tsx
+++ b/src/frontend/src/components/common/organizationDisplay/index.tsx
@@ -1,0 +1,40 @@
+import { IS_CLERK_AUTH } from "@/clerk/auth";
+import { useOrganization } from "@clerk/clerk-react";
+import { Building2 } from "lucide-react";
+
+/**
+ * Component that displays the organization name when Clerk authentication is enabled.
+ * Shows the organization name with an icon, only visible when authenticated via Clerk.
+ */
+export function OrganizationDisplay() {
+  const { organization, isLoaded } = useOrganization();
+
+  // Don't render if Clerk auth is not enabled
+  if (!IS_CLERK_AUTH) {
+    return null;
+  }
+
+  // Don't render if organization data is not loaded yet
+  if (!isLoaded) {
+    return null;
+  }
+
+  // Don't render if no organization is selected
+  if (!organization) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-md bg-muted/30 px-2.5 py-1 text-xs transition-colors hover:bg-muted/50"
+      data-testid="organization-display"
+    >
+      <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="font-medium text-foreground/90 max-w-[200px] truncate">
+        {organization.name}
+      </span>
+    </div>
+  );
+}
+
+export default OrganizationDisplay;

--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -2,6 +2,7 @@ import AlertDropdown from "@/alerts/alertDropDown";
 import DataStaxLogo from "@/assets/DataStaxLogo.svg?react";
 import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import OrganizationDisplay from "@/components/common/organizationDisplay";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -71,6 +72,8 @@ export default function AppHeader(): JSX.Element {
             <LangflowLogo className="h-6 w-6" />
           )}
         </Button>
+        {/* Display organization name when Clerk auth is enabled */}
+        <OrganizationDisplay />
         {ENABLE_DATASTAX_LANGFLOW && (
           <>
             <CustomOrgSelector />


### PR DESCRIPTION
## Summary
- add an organization display component that surfaces the active Clerk organization
- render the organization name in the application header when Clerk authentication is enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8d029f9483269e82d3e0c5074a51