### PR TITLE
Sync Clerk organization selection state

### DIFF
--- a/src/frontend/src/clerk/auth.tsx
+++ b/src/frontend/src/clerk/auth.tsx
@@ -118,10 +118,33 @@ export function ClerkAuthAdapter() {
   console.log("[ClerkAuthAdapter] Render", {
     isSignedIn,
     isOrgSelected,
-    currentPath
+    currentPath,
+    organizationId: organization?.id
   });
 
+  // ✅ Sync Clerk organization state with our local state
+  // If Clerk has loaded an organization (from previous session), mark it as selected
+  useEffect(() => {
+    if (
+      IS_CLERK_AUTH &&
+      isSignedIn &&
+      isOrgLoaded &&
+      organization?.id &&
+      !isOrgSelected
+    ) {
+      console.log("[ClerkAuthAdapter] Clerk organization already loaded, syncing to local state");
+      authStore.getState().setIsOrgSelected(true);
+      sessionStorage.setItem("isOrgSelected", "true");
+    }
+  }, [isSignedIn, isOrgLoaded, organization?.id, isOrgSelected]);
+
   // ✅ Redirect to /organization if signed in but org not selected
+  // Only redirect if:
+  // 1. User is signed in
+  // 2. Organization context is loaded
+  // 3. No organization is selected in sessionStorage/store
+  // 4. Clerk doesn't have an active organization (meaning user never picked one)
+  // 5. User is at root or login page
   useEffect(() => {
     if (
       IS_CLERK_AUTH &&
@@ -134,7 +157,7 @@ export function ClerkAuthAdapter() {
       console.log("[ClerkAuthAdapter] Redirecting to /organization (no org selected)");
       navigate("/organization", { replace: true });
     }
-  }, [isSignedIn, isOrgLoaded, organization?.id, currentPath]);
+  }, [isSignedIn, isOrgLoaded, organization?.id, currentPath, isOrgSelected]);
 
 
   // ✅ Clerk token listener: backend sync ONLY after org is selected

--- a/src/frontend/src/clerk/syncOrgState.ts
+++ b/src/frontend/src/clerk/syncOrgState.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import useAuthStore from "@/stores/authStore";
+
+/**
+ * Hook to sync Clerk organization state with local state
+ */
+export function useSyncClerkOrgState({
+  isSignedIn,
+  isOrgLoaded,
+  orgId,
+  isOrgSelected,
+}: {
+  isSignedIn: boolean;
+  isOrgLoaded: boolean;
+  orgId?: string;
+  isOrgSelected: boolean;
+}) {
+  useEffect(() => {
+    if (isSignedIn && isOrgLoaded && orgId && !isOrgSelected) {
+      console.log("[useSyncClerkOrgState] Syncing Clerk org to local state");
+      useAuthStore.getState().setIsOrgSelected(true);
+      sessionStorage.setItem("isOrgSelected", "true");
+    }
+  }, [isSignedIn, isOrgLoaded, orgId, isOrgSelected]);
+}

--- a/src/frontend/src/components/authorization/authGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authGuard/index.tsx
@@ -9,6 +9,7 @@ import useAuthStore from "@/stores/authStore";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useOrganization, useAuth as useClerkAuth } from "@clerk/clerk-react";
+import { useSyncClerkOrgState } from "@/clerk/syncOrgState";
 
 export const ProtectedRoute = ({ children }) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -24,7 +25,7 @@ export const ProtectedRoute = ({ children }) => {
   const { isSignedIn } = useClerkAuth();
   const orgId = organization?.id;
 
-  
+  useSyncClerkOrgState({ isSignedIn, isOrgLoaded, orgId, isOrgSelected });
   // Get current path
   const location = useLocation();
   const currentPath = location.pathname;


### PR DESCRIPTION
## Summary
- ensure the Clerk auth adapter logs the active organization and syncs existing Clerk selections to local state
- add a reusable hook to copy Clerk organization selection into the auth store and session storage
- use the new hook in the auth guard to keep protected routes aligned with Clerk state

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9bf473ac832697ac60d865e75a8f