### PR TITLE
Refine organization avatar responsiveness

### DIFF
--- a/src/frontend/src/components/common/organizationDisplay/index.tsx
+++ b/src/frontend/src/components/common/organizationDisplay/index.tsx
@@ -1,7 +1,7 @@
 import { IS_CLERK_AUTH, useLogout } from "@/clerk/auth";
 import { useOrganization } from "@clerk/clerk-react";
 import { Building2, ChevronDown, LogOut } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -20,6 +20,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
 
 /**
  * Component that displays the organization name when Clerk authentication is enabled.
@@ -45,6 +50,22 @@ export function OrganizationDisplay() {
     return null;
   }
 
+  const organizationImageUrl = organization.imageUrl;
+  const organizationInitials = useMemo(() => {
+    if (!organization.name) {
+      return "";
+    }
+
+    const [firstWord = "", secondWord = ""] = organization.name
+      .split(/\s+/)
+      .filter(Boolean);
+
+    const firstInitial = firstWord.charAt(0) ?? "";
+    const secondInitial = secondWord.charAt(0) ?? "";
+
+    return `${firstInitial}${secondInitial}`.toUpperCase();
+  }, [organization.name]);
+
   const handleLogout = () => {
     mutationLogout();
     setShowSwitchModal(false);
@@ -57,16 +78,27 @@ export function OrganizationDisplay() {
   return (
     <>
       <div
-        className="flex items-center gap-1.5 rounded-md bg-muted/30 px-2.5 py-1 h-auto transition-colors hover:bg-muted/50"
+        className="flex min-w-0 items-center gap-1.5 rounded-md bg-muted/30 px-2 py-1 transition-colors hover:bg-muted/50 sm:px-2.5"
         data-testid="organization-display"
+        aria-label={organization.name}
       >
-        <Building2 className="h-4 w-4 text-muted-foreground" />
+        <Avatar className="h-6 w-6 shrink-0 border border-border bg-muted">
+          <AvatarImage
+            src={organizationImageUrl ?? undefined}
+            alt={`${organization.name} logo`}
+            loading="lazy"
+          />
+          <AvatarFallback className="bg-muted text-xs font-semibold text-muted-foreground">
+            {organizationInitials || <Building2 className="h-4 w-4" aria-hidden="true" />}
+          </AvatarFallback>
+        </Avatar>
+        <span className="sr-only sm:hidden">{organization.name}</span>
         <ShadTooltip
           content={organization.name}
           side="bottom"
           delayDuration={300}
         >
-          <span className="font-semibold text-sm text-foreground max-w-[200px] truncate">
+          <span className="hidden text-sm font-semibold text-foreground sm:block sm:max-w-[200px] sm:truncate">
             {organization.name}
           </span>
         </ShadTooltip>


### PR DESCRIPTION
## Summary
- replace the custom organization logo wrapper with the shared Avatar component so Clerk-provided artwork and fallbacks render consistently
- add responsive name handling that hides the label visually on small screens while keeping it accessible and preventing overlap with the flow title
- derive initials as a graceful fallback when an organization image is unavailable

## Testing
- pnpm --filter frontend lint *(fails: No projects matched the filters in "/workspace/DragDropAIAgentBuilder")*

------
https://chatgpt.com/codex/tasks/task_e_68e26b0614848326bcfdecf6724c76c0