### PR TITLE
Improve header responsiveness

### DIFF
--- a/src/frontend/src/components/common/organizationDisplay/index.tsx
+++ b/src/frontend/src/components/common/organizationDisplay/index.tsx
@@ -56,46 +56,46 @@ export function OrganizationDisplay() {
 
   return (
     <>
-      <div
-        className="flex items-center gap-1.5 rounded-md bg-muted/30 px-2.5 py-1 h-auto transition-colors hover:bg-muted/50"
-        data-testid="organization-display"
+      <ShadTooltip
+        content={organization.name}
+        side="bottom"
+        delayDuration={300}
       >
-        <Building2 className="h-4 w-4 text-muted-foreground" />
-        <ShadTooltip
-          content={organization.name}
-          side="bottom"
-          delayDuration={300}
+        <div
+          className="flex items-center gap-1 rounded-md bg-muted/30 px-2 py-1 h-auto transition-colors hover:bg-muted/50 shrink-0"
+          data-testid="organization-display"
         >
-          <span className="font-semibold text-sm text-foreground max-w-[200px] truncate">
+          <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="font-semibold text-sm text-foreground max-w-[200px] truncate hidden lg:inline-block">
             {organization.name}
           </span>
-        </ShadTooltip>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Organization options"
-              className="h-6 w-6 p-0 text-muted-foreground hover:bg-muted/60"
-            >
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel className="font-semibold">
-              {organization.name}
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setShowSwitchModal(true)}
-              className="cursor-pointer"
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              <span>Switch Organisation</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Organization options"
+                className="h-5 w-5 p-0 text-muted-foreground hover:bg-muted/60 shrink-0"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel className="font-semibold">
+                {organization.name}
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setShowSwitchModal(true)}
+                className="cursor-pointer"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                <span>Switch Organisation</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </ShadTooltip>
 
       <Dialog open={showSwitchModal} onOpenChange={setShowSwitchModal}>
         <DialogContent>

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
@@ -1,81 +1,51 @@
 /* Responsive styles for flow name display in the header */
 
 .flow-name-responsive {
-  flex: 1 1 22rem;
+  flex: 1 1 auto;
   min-width: 0;
-  max-width: 100%;
+  max-width: clamp(12rem, 32vw, 22rem);
 }
 
 .flow-name-responsive .flow-name-text {
   display: block;
   min-width: 0;
-  max-width: min(32rem, 100%);
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-@media (max-width: 1380px) {
-  .flow-name-responsive {
-    flex-basis: 20rem;
-  }
-}
-
 @media (max-width: 1200px) {
   .flow-name-responsive {
-    flex-basis: 18rem;
+    max-width: clamp(10rem, 34vw, 20rem);
   }
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 992px) {
   .flow-name-responsive {
-    flex-basis: 16rem;
+    max-width: clamp(8.5rem, 40vw, 18rem);
   }
 }
 
-@media (max-width: 980px) {
+@media (max-width: 768px) {
   .flow-name-responsive {
-    flex-basis: 14rem;
+    max-width: clamp(7rem, 46vw, 16rem);
   }
 }
 
-@media (max-width: 880px) {
+@media (max-width: 640px) {
   .flow-name-responsive {
-    flex-basis: 12rem;
+    max-width: clamp(6rem, 52vw, 14rem);
   }
 }
 
-@media (max-width: 780px) {
+@media (max-width: 520px) {
   .flow-name-responsive {
-    flex-basis: 10rem;
+    max-width: clamp(5rem, 60vw, 12rem);
   }
 }
 
-@media (max-width: 680px) {
+@media (max-width: 440px) {
   .flow-name-responsive {
-    flex-basis: 8rem;
-  }
-}
-
-@media (max-width: 600px) {
-  .flow-name-responsive {
-    flex-basis: 7rem;
-  }
-}
-
-@media (max-width: 540px) {
-  .flow-name-responsive {
-    flex-basis: 6rem;
-  }
-}
-
-@media (max-width: 500px) {
-  .flow-name-responsive {
-    flex-basis: 5rem;
-  }
-}
-
-@media (max-width: 460px) {
-  .flow-name-responsive {
-    flex-basis: 4rem;
+    max-width: clamp(4.25rem, 68vw, 10rem);
   }
 }

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
@@ -1,0 +1,29 @@
+/* Responsive styles for flow name display in the header */
+
+/* Default: Show flow name text normally */
+.flow-name-responsive .flow-name-text {
+  display: inline;
+}
+
+/* On small screens (< md): Show only first 2 characters */
+@media (max-width: 767px) {
+  .flow-name-responsive .flow-name-text {
+    max-width: 2ch;
+    overflow: hidden;
+    text-overflow: clip;
+  }
+}
+
+/* On medium screens (md to lg): Truncate flow name more aggressively */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .flow-name-responsive .flow-name-text {
+    max-width: 25vw;
+  }
+}
+
+/* On large screens (>= lg): Full flow name with normal truncation */
+@media (min-width: 1024px) {
+  .flow-name-responsive .flow-name-text {
+    max-width: 35vw;
+  }
+}

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
@@ -1,34 +1,81 @@
 /* Responsive styles for flow name display in the header */
 
-/* Default: Show flow name text normally */
-.flow-name-responsive .flow-name-text {
-  display: inline-block;
+.flow-name-responsive {
+  flex: 1 1 22rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
-/* Provide a flexible but intuitive truncation with ellipsis */
 .flow-name-responsive .flow-name-text {
-  max-width: clamp(10rem, 30vw, 22rem);
+  display: block;
+  min-width: 0;
+  max-width: min(32rem, 100%);
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* On large tablets / small laptops allow a slightly smaller label */
-@media (max-width: 1023px) {
-  .flow-name-responsive .flow-name-text {
-    max-width: clamp(8rem, 34vw, 18rem);
+@media (max-width: 1380px) {
+  .flow-name-responsive {
+    flex-basis: 20rem;
   }
 }
 
-/* On small tablets the label keeps shrinking while keeping ellipsis visible */
-@media (max-width: 899px) {
-  .flow-name-responsive .flow-name-text {
-    max-width: clamp(7rem, 40vw, 16rem);
+@media (max-width: 1200px) {
+  .flow-name-responsive {
+    flex-basis: 18rem;
   }
 }
 
-/* On mobile sizes give the flow name most of the available width */
-@media (max-width: 639px) {
-  .flow-name-responsive .flow-name-text {
-    max-width: clamp(6rem, 60vw, 14rem);
+@media (max-width: 1100px) {
+  .flow-name-responsive {
+    flex-basis: 16rem;
+  }
+}
+
+@media (max-width: 980px) {
+  .flow-name-responsive {
+    flex-basis: 14rem;
+  }
+}
+
+@media (max-width: 880px) {
+  .flow-name-responsive {
+    flex-basis: 12rem;
+  }
+}
+
+@media (max-width: 780px) {
+  .flow-name-responsive {
+    flex-basis: 10rem;
+  }
+}
+
+@media (max-width: 680px) {
+  .flow-name-responsive {
+    flex-basis: 8rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .flow-name-responsive {
+    flex-basis: 7rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .flow-name-responsive {
+    flex-basis: 6rem;
+  }
+}
+
+@media (max-width: 500px) {
+  .flow-name-responsive {
+    flex-basis: 5rem;
+  }
+}
+
+@media (max-width: 460px) {
+  .flow-name-responsive {
+    flex-basis: 4rem;
   }
 }

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
@@ -1,51 +1,146 @@
-/* Responsive styles for flow name display in the header */
+/* Responsive layout and tooltip styling for the flow menu header */
 
-.flow-name-responsive {
-  flex: 1 1 auto;
-  min-width: 0;
-  max-width: clamp(12rem, 32vw, 22rem);
+[data-testid="menu_bar_wrapper"] {
+  padding-inline: 0.5rem;
+  gap: 0.75rem;
+  flex-wrap: nowrap;
 }
 
-.flow-name-responsive .flow-name-text {
+@media (min-width: 640px) {
+  [data-testid="menu_bar_wrapper"] {
+    padding-inline: 1rem;
+    gap: 1rem;
+  }
+}
+
+[data-testid="menu_bar_wrapper"] > div.flex.rounded {
+  flex-shrink: 0;
+}
+
+@media (max-width: 1023.98px) {
+  .header-menu-bar,
+  [data-testid="menu_bar_separator"] {
+    display: none !important;
+  }
+}
+
+[data-testid="menu_bar_display"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-right: 0;
+  gap: 0.5rem;
+  padding-inline-end: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  [data-testid="menu_bar_display"] {
+    gap: 0.75rem;
+    padding-inline-end: 1rem;
+  }
+}
+
+[data-testid="menu_bar_display"] [data-testid="flow_name"] {
   display: block;
   min-width: 0;
-  max-width: 100%;
+  max-width: clamp(6rem, 42vw, 20rem);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 1200px) {
-  .flow-name-responsive {
-    max-width: clamp(10rem, 34vw, 20rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(5.5rem, 40vw, 18rem);
   }
 }
 
 @media (max-width: 992px) {
-  .flow-name-responsive {
-    max-width: clamp(8.5rem, 40vw, 18rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(5rem, 46vw, 16rem);
   }
 }
 
 @media (max-width: 768px) {
-  .flow-name-responsive {
-    max-width: clamp(7rem, 46vw, 16rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(4.5rem, 52vw, 14rem);
   }
 }
 
 @media (max-width: 640px) {
-  .flow-name-responsive {
-    max-width: clamp(6rem, 52vw, 14rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(4rem, 60vw, 12rem);
   }
 }
 
 @media (max-width: 520px) {
-  .flow-name-responsive {
-    max-width: clamp(5rem, 60vw, 12rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(3.5rem, 68vw, 10rem);
   }
 }
 
 @media (max-width: 440px) {
-  .flow-name-responsive {
-    max-width: clamp(4.25rem, 68vw, 10rem);
+  [data-testid="menu_bar_display"] [data-testid="flow_name"] {
+    max-width: clamp(3rem, 74vw, 8.5rem);
   }
+}
+
+[data-testid="flow_name"][data-tooltip] {
+  position: relative;
+}
+
+[data-testid="flow_name"][data-tooltip]::after,
+[data-testid="flow_name"][data-tooltip]::before {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+}
+
+[data-testid="flow_name"][data-tooltip]::after {
+  transform: translateY(4px);
+}
+
+[data-testid="flow_name"][data-tooltip]::before {
+  transform: translateY(4px) rotate(45deg);
+}
+
+[data-testid="flow_name"][data-tooltip]:hover::after,
+[data-testid="flow_name"][data-tooltip]:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.35rem);
+  z-index: 50;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.375rem;
+  background-color: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 12px 28px -12px rgba(15, 23, 42, 0.45);
+  white-space: nowrap;
+  max-width: min(80vw, 22rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 1;
+}
+
+[data-testid="flow_name"][data-tooltip]:hover::before,
+[data-testid="flow_name"][data-tooltip]:focus-visible::before {
+  content: "";
+  position: absolute;
+  top: calc(100% + 0.12rem);
+  left: 0.8rem;
+  width: 0.625rem;
+  height: 0.625rem;
+  background-color: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  border-top-color: transparent;
+  border-left-color: transparent;
+  transform: translateY(0) rotate(45deg);
+  box-shadow: 0 12px 28px -12px rgba(15, 23, 42, 0.35);
+  opacity: 1;
+}
+
+[data-testid="flow_name"][data-tooltip]:hover::after,
+[data-testid="flow_name"][data-tooltip]:focus-visible::after {
+  transform: translateY(-2px);
 }

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/flowMenuResponsive.css
@@ -2,28 +2,33 @@
 
 /* Default: Show flow name text normally */
 .flow-name-responsive .flow-name-text {
-  display: inline;
+  display: inline-block;
 }
 
-/* On small screens (< md): Show only first 2 characters */
-@media (max-width: 767px) {
+/* Provide a flexible but intuitive truncation with ellipsis */
+.flow-name-responsive .flow-name-text {
+  max-width: clamp(10rem, 30vw, 22rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* On large tablets / small laptops allow a slightly smaller label */
+@media (max-width: 1023px) {
   .flow-name-responsive .flow-name-text {
-    max-width: 2ch;
-    overflow: hidden;
-    text-overflow: clip;
+    max-width: clamp(8rem, 34vw, 18rem);
   }
 }
 
-/* On medium screens (md to lg): Truncate flow name more aggressively */
-@media (min-width: 768px) and (max-width: 1023px) {
+/* On small tablets the label keeps shrinking while keeping ellipsis visible */
+@media (max-width: 899px) {
   .flow-name-responsive .flow-name-text {
-    max-width: 25vw;
+    max-width: clamp(7rem, 40vw, 16rem);
   }
 }
 
-/* On large screens (>= lg): Full flow name with normal truncation */
-@media (min-width: 1024px) {
+/* On mobile sizes give the flow name most of the available width */
+@media (max-width: 639px) {
   .flow-name-responsive .flow-name-text {
-    max-width: 35vw;
+    max-width: clamp(6rem, 60vw, 14rem);
   }
 }

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -92,79 +92,81 @@ export const MenuBar = memo((): JSX.Element => {
     <Popover open={openSettings} onOpenChange={setOpenSettings}>
       <PopoverAnchor>
           <div
-            className="relative flex w-full items-center justify-center gap-3 px-3 sm:px-4"
+            className="relative flex w-full items-center gap-3 px-2 sm:px-4"
             data-testid="menu_bar_wrapper"
           >
-          <div
-            className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
-            data-testid="menu_flow_bar"
-            id="menu_flow_bar_navigation"
-          >
-            {currentFolder?.name && (
-              <div className="hidden truncate md:flex">
-                <div
-                  className="cursor-pointer truncate text-sm text-muted-foreground hover:text-primary"
-                  onClick={() => {
-                    navigate(
-                      currentFolder?.id
-                        ? "/all/folder/" + currentFolder.id
-                        : "/all",
-                    );
-                  }}
-                >
-                  {currentFolder?.name}
-                </div>
-              </div>
-            )}
-          </div>
-          <div
-            className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground lg:flex"
-            data-testid="menu_bar_separator"
-          >
-            /
-          </div>
-          <div className={cn(`flex rounded p-1`, swatchColors[swatchIndex])}>
-            <IconComponent
-              name={currentFlowIcon ?? "Workflow"}
-              className="h-3.5 w-3.5"
-            />
-          </div>
-          <PopoverTrigger asChild>
             <div
-              className="group relative flex min-w-0 cursor-pointer items-center gap-2 pr-2 text-sm sm:whitespace-normal flow-name-responsive"
-              data-testid="menu_bar_display"
+              className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
+              data-testid="menu_flow_bar"
+              id="menu_flow_bar_navigation"
             >
-              <ShadTooltip
-                content={currentFlowName || "Untitled Flow"}
-                side="bottom"
-                delayDuration={300}
-              >
-                <span
-                  ref={measureRef}
-                  className="flow-name-text w-full truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
-                  aria-hidden="true"
-                  data-testid="flow_name"
-                >
-                  {currentFlowName || "Untitled Flow"}
-                </span>
-              </ShadTooltip>
-
-              <IconComponent
-                name="pencil"
-                className={cn(
-                  "h-5 w-3.5 -translate-x-2 opacity-0 transition-all",
-                  !openSettings &&
-                    "sm:group-hover:translate-x-0 sm:group-hover:opacity-100",
-                )}
-              />
+              {currentFolder?.name && (
+                <div className="hidden truncate md:flex">
+                  <div
+                    className="cursor-pointer truncate text-sm text-muted-foreground hover:text-primary"
+                    onClick={() => {
+                      navigate(
+                        currentFolder?.id
+                          ? "/all/folder/" + currentFolder.id
+                          : "/all",
+                      );
+                    }}
+                  >
+                    {currentFolder?.name}
+                  </div>
+                </div>
+              )}
             </div>
-          </PopoverTrigger>
-          <div className={"ml-5 hidden shrink-0 items-center sm:flex"}>
-            {!autoSaving && (
-              <ShadTooltip
-                content={
-                  changesNotSaved
-                    ? saveLoading
+            <div
+              className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground lg:flex"
+              data-testid="menu_bar_separator"
+            >
+              /
+            </div>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <div className={cn(`flex shrink-0 rounded p-1`, swatchColors[swatchIndex])}>
+                <IconComponent
+                  name={currentFlowIcon ?? "Workflow"}
+                  className="h-3.5 w-3.5"
+                />
+              </div>
+              <PopoverTrigger asChild>
+                <div
+                  className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 pr-2 text-sm sm:whitespace-normal flow-name-responsive"
+                  data-testid="menu_bar_display"
+                >
+                  <ShadTooltip
+                    content={currentFlowName || "Untitled Flow"}
+                    side="bottom"
+                    delayDuration={300}
+                  >
+                    <span
+                      ref={measureRef}
+                      className="flow-name-text block min-w-0 truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
+                      aria-hidden="true"
+                      data-testid="flow_name"
+                    >
+                      {currentFlowName || "Untitled Flow"}
+                    </span>
+                  </ShadTooltip>
+
+                  <IconComponent
+                    name="pencil"
+                    className={cn(
+                      "h-5 w-3.5 -translate-x-2 opacity-0 transition-all",
+                      !openSettings &&
+                        "sm:group-hover:translate-x-0 sm:group-hover:opacity-100",
+                    )}
+                  />
+                </div>
+              </PopoverTrigger>
+            </div>
+            <div className="ml-auto hidden shrink-0 items-center sm:flex">
+              {!autoSaving && (
+                <ShadTooltip
+                  content={
+                    changesNotSaved
+                      ? saveLoading
                       ? "Saving..."
                       : "Save Changes"
                     : SAVED_HOVER +

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -92,81 +92,74 @@ export const MenuBar = memo((): JSX.Element => {
     <Popover open={openSettings} onOpenChange={setOpenSettings}>
       <PopoverAnchor>
         <div
-          className="relative flex w-full flex-nowrap items-center gap-3 px-2 sm:px-4"
+          className="relative flex w-full items-center justify-center gap-2"
           data-testid="menu_bar_wrapper"
         >
-            <div
-              className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
-              data-testid="menu_flow_bar"
-              id="menu_flow_bar_navigation"
-            >
-              {currentFolder?.name && (
-                <div className="hidden truncate md:flex">
-                  <div
-                    className="cursor-pointer truncate text-sm text-muted-foreground hover:text-primary"
-                    onClick={() => {
-                      navigate(
-                        currentFolder?.id
-                          ? "/all/folder/" + currentFolder.id
-                          : "/all",
-                      );
-                    }}
-                  >
-                    {currentFolder?.name}
-                  </div>
-                </div>
-              )}
-            </div>
-            <div
-              className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground lg:flex"
-              data-testid="menu_bar_separator"
-            >
-              /
-            </div>
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <div className={cn(`flex shrink-0 rounded p-1`, swatchColors[swatchIndex])}>
-                <IconComponent
-                  name={currentFlowIcon ?? "Workflow"}
-                  className="h-3.5 w-3.5"
-                />
-              </div>
-              <PopoverTrigger asChild>
+          <div
+            className="header-menu-bar hidden max-w-40 justify-end truncate md:flex xl:max-w-full"
+            data-testid="menu_flow_bar"
+            id="menu_flow_bar_navigation"
+          >
+            {currentFolder?.name && (
+              <div className="hidden truncate md:flex">
                 <div
-                  className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 pr-3 text-sm sm:whitespace-normal sm:gap-3 sm:pr-4 flow-name-responsive"
-                  data-testid="menu_bar_display"
+                  className="cursor-pointer truncate text-sm text-muted-foreground hover:text-primary"
+                  onClick={() => {
+                    navigate(
+                      currentFolder?.id
+                        ? "/all/folder/" + currentFolder.id
+                        : "/all",
+                    );
+                  }}
                 >
-                  <ShadTooltip
-                    content={currentFlowName || "Untitled Flow"}
-                    side="bottom"
-                    delayDuration={300}
-                  >
-                    <span
-                      ref={measureRef}
-                      className="flow-name-text block min-w-0 truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
-                      aria-hidden="true"
-                      data-testid="flow_name"
-                    >
-                      {currentFlowName || "Untitled Flow"}
-                    </span>
-                  </ShadTooltip>
-
-                  <IconComponent
-                    name="pencil"
-                    className={cn(
-                      "h-5 w-3.5 -translate-x-2 opacity-0 transition-all",
-                      !openSettings &&
-                        "sm:group-hover:translate-x-0 sm:group-hover:opacity-100",
-                    )}
-                  />
+                  {currentFolder?.name}
                 </div>
-              </PopoverTrigger>
+              </div>
+            )}
+          </div>
+          <div
+            className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground md:flex"
+            data-testid="menu_bar_separator"
+          >
+            /
+          </div>
+          <div className={cn(`flex rounded p-1`, swatchColors[swatchIndex])}>
+            <IconComponent
+              name={currentFlowIcon ?? "Workflow"}
+              className="h-3.5 w-3.5"
+            />
+          </div>
+          <PopoverTrigger asChild>
+            <div
+              className="group relative -mr-5 flex shrink-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal"
+              data-testid="menu_bar_display"
+            >
+              <span
+                ref={measureRef}
+                className="w-fit max-w-[35vw] truncate whitespace-pre text-mmd font-semibold sm:max-w-full sm:text-sm"
+                data-tooltip={currentFlowName || "Untitled Flow"}
+                aria-hidden="true"
+                data-testid="flow_name"
+              >
+                {currentFlowName || "Untitled Flow"}
+              </span>
+
+              <IconComponent
+                name="pencil"
+                className={cn(
+                  "h-5 w-3.5 -translate-x-2 opacity-0 transition-all",
+                  !openSettings &&
+                    "sm:group-hover:translate-x-0 sm:group-hover:opacity-100",
+                )}
+              />
             </div>
-            <div className="ml-auto hidden shrink-0 items-center sm:flex">
-              {!autoSaving && (
-                <ShadTooltip
-                  content={
-                    changesNotSaved
-                      ? saveLoading
+          </PopoverTrigger>
+          <div className={"ml-5 hidden shrink-0 items-center sm:flex"}>
+            {!autoSaving && (
+              <ShadTooltip
+                content={
+                  changesNotSaved
+                    ? saveLoading
                       ? "Saving..."
                       : "Save Changes"
                     : SAVED_HOVER +

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -91,10 +91,10 @@ export const MenuBar = memo((): JSX.Element => {
   return onFlowPage ? (
     <Popover open={openSettings} onOpenChange={setOpenSettings}>
       <PopoverAnchor>
-        <div
-          className="relative flex w-full items-center justify-center gap-2"
-          data-testid="menu_bar_wrapper"
-        >
+          <div
+            className="relative flex w-full items-center justify-center gap-2 px-2"
+            data-testid="menu_bar_wrapper"
+          >
           <div
             className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
             data-testid="menu_flow_bar"
@@ -131,18 +131,23 @@ export const MenuBar = memo((): JSX.Element => {
           </div>
           <PopoverTrigger asChild>
             <div
-              className="group relative -mr-5 flex shrink-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal flow-name-responsive"
+              className="group relative flex min-w-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal flow-name-responsive"
               data-testid="menu_bar_display"
             >
-              <span
-                ref={measureRef}
-                className="flow-name-text w-fit truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
-                aria-hidden="true"
-                title={currentFlowName || "Untitled Flow"}
-                data-testid="flow_name"
+              <ShadTooltip
+                content={currentFlowName || "Untitled Flow"}
+                side="bottom"
+                delayDuration={300}
               >
-                {currentFlowName || "Untitled Flow"}
-              </span>
+                <span
+                  ref={measureRef}
+                  className="flow-name-text w-fit truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
+                  aria-hidden="true"
+                  data-testid="flow_name"
+                >
+                  {currentFlowName || "Untitled Flow"}
+                </span>
+              </ShadTooltip>
 
               <IconComponent
                 name="pencil"

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -96,7 +96,7 @@ export const MenuBar = memo((): JSX.Element => {
           data-testid="menu_bar_wrapper"
         >
           <div
-            className="header-menu-bar hidden max-w-40 justify-end truncate md:flex xl:max-w-full"
+            className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
             data-testid="menu_flow_bar"
             id="menu_flow_bar_navigation"
           >
@@ -118,7 +118,7 @@ export const MenuBar = memo((): JSX.Element => {
             )}
           </div>
           <div
-            className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground md:flex"
+            className="hidden w-fit shrink-0 select-none font-normal text-muted-foreground lg:flex"
             data-testid="menu_bar_separator"
           >
             /
@@ -136,8 +136,9 @@ export const MenuBar = memo((): JSX.Element => {
             >
               <span
                 ref={measureRef}
-                className="flow-name-text w-fit max-w-[35vw] truncate whitespace-pre text-mmd font-semibold sm:max-w-full sm:text-sm"
+                className="flow-name-text w-fit truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
                 aria-hidden="true"
+                title={currentFlowName || "Untitled Flow"}
                 data-testid="flow_name"
               >
                 {currentFlowName || "Untitled Flow"}

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -24,6 +24,7 @@ import { swatchColors } from "@/utils/styleUtils";
 import { cn, getNumberFromString } from "@/utils/utils";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useShallow } from "zustand/react/shallow";
+import "./flowMenuResponsive.css";
 
 export const MenuBar = memo((): JSX.Element => {
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
@@ -130,12 +131,12 @@ export const MenuBar = memo((): JSX.Element => {
           </div>
           <PopoverTrigger asChild>
             <div
-              className="group relative -mr-5 flex shrink-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal"
+              className="group relative -mr-5 flex shrink-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal flow-name-responsive"
               data-testid="menu_bar_display"
             >
               <span
                 ref={measureRef}
-                className="w-fit max-w-[35vw] truncate whitespace-pre text-mmd font-semibold sm:max-w-full sm:text-sm"
+                className="flow-name-text w-fit max-w-[35vw] truncate whitespace-pre text-mmd font-semibold sm:max-w-full sm:text-sm"
                 aria-hidden="true"
                 data-testid="flow_name"
               >

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -91,10 +91,10 @@ export const MenuBar = memo((): JSX.Element => {
   return onFlowPage ? (
     <Popover open={openSettings} onOpenChange={setOpenSettings}>
       <PopoverAnchor>
-          <div
-            className="relative flex w-full items-center gap-3 px-2 sm:px-4"
-            data-testid="menu_bar_wrapper"
-          >
+        <div
+          className="relative flex w-full flex-nowrap items-center gap-3 px-2 sm:px-4"
+          data-testid="menu_bar_wrapper"
+        >
             <div
               className="header-menu-bar hidden max-w-40 justify-end truncate lg:flex xl:max-w-full"
               data-testid="menu_flow_bar"
@@ -132,7 +132,7 @@ export const MenuBar = memo((): JSX.Element => {
               </div>
               <PopoverTrigger asChild>
                 <div
-                  className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 pr-2 text-sm sm:whitespace-normal flow-name-responsive"
+                  className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 pr-3 text-sm sm:whitespace-normal sm:gap-3 sm:pr-4 flow-name-responsive"
                   data-testid="menu_bar_display"
                 >
                   <ShadTooltip

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -92,7 +92,7 @@ export const MenuBar = memo((): JSX.Element => {
     <Popover open={openSettings} onOpenChange={setOpenSettings}>
       <PopoverAnchor>
           <div
-            className="relative flex w-full items-center justify-center gap-2 px-2"
+            className="relative flex w-full items-center justify-center gap-3 px-3 sm:px-4"
             data-testid="menu_bar_wrapper"
           >
           <div
@@ -131,7 +131,7 @@ export const MenuBar = memo((): JSX.Element => {
           </div>
           <PopoverTrigger asChild>
             <div
-              className="group relative flex min-w-0 cursor-pointer items-center gap-2 text-sm sm:whitespace-normal flow-name-responsive"
+              className="group relative flex min-w-0 cursor-pointer items-center gap-2 pr-2 text-sm sm:whitespace-normal flow-name-responsive"
               data-testid="menu_bar_display"
             >
               <ShadTooltip
@@ -141,7 +141,7 @@ export const MenuBar = memo((): JSX.Element => {
               >
                 <span
                   ref={measureRef}
-                  className="flow-name-text w-fit truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
+                  className="flow-name-text w-full truncate whitespace-nowrap text-mmd font-semibold sm:text-sm"
                   aria-hidden="true"
                   data-testid="flow_name"
                 >

--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -57,13 +57,13 @@ export default function AppHeader(): JSX.Element {
     >
       {/* Left Section */}
       <div
-        className={`z-30 flex items-center gap-2`}
+        className={`z-30 flex items-center gap-2 shrink-0`}
         data-testid="header_left_section_wrapper"
       >
         <Button
           unstyled
           onClick={() => navigate("/")}
-          className="mr-1 flex h-8 w-8 items-center"
+          className="mr-1 flex h-8 w-8 items-center shrink-0"
           data-testid="icon-ChevronLeft"
         >
           {ENABLE_DATASTAX_LANGFLOW ? (
@@ -83,13 +83,13 @@ export default function AppHeader(): JSX.Element {
       </div>
 
       {/* Middle Section */}
-      <div className="absolute left-1/2 w-full flex-1 -translate-x-1/2">
+      <div className="flex-1 flex justify-center px-4 min-w-0">
         <FlowMenu />
       </div>
 
       {/* Right Section */}
       <div
-        className={`relative left-3 z-30 flex items-center gap-3`}
+        className={`z-30 flex items-center gap-3 shrink-0`}
         data-testid="header_right_section_wrapper"
       >
         <>

--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -83,7 +83,7 @@ export default function AppHeader(): JSX.Element {
       </div>
 
       {/* Middle Section */}
-      <div className="flex-1 flex justify-center px-4 min-w-0">
+      <div className="flex-1 flex justify-center px-4 min-w-0 overflow-hidden">
         <FlowMenu />
       </div>
 


### PR DESCRIPTION
## Summary
- wrap the organization display in a tooltip and adjust button/icon sizing for smaller viewports
- add responsive styling for the flow name and flex constraints in the app header to avoid layout overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e9763a488326847c564d510198c7