### PR TITLE
Fix Langflow header navigation redirect

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -62,7 +62,7 @@ export default function AppHeader(): JSX.Element {
       >
         <Button
           unstyled
-          onClick={() => navigate("/")}
+          onClick={() => navigate("flows")}
           className="mr-1 flex h-8 w-8 items-center"
           data-testid="icon-ChevronLeft"
         >


### PR DESCRIPTION
## Summary
- update the app header Langflow logo click handler to navigate to the flows collection instead of the root path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8bf74e4e08326b59f36bfad4de7df