### PR TITLE
Add Clerk frontend API env vars to staging/prod builds

### DIFF
--- a/.github/workflows/ebs-common-stage-prod.yml
+++ b/.github/workflows/ebs-common-stage-prod.yml
@@ -113,6 +113,7 @@ jobs:
           VITE_AUTO_LOGIN=false \
           VITE_CLERK_AUTH_ENABLED=true \
           VITE_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }} \
+          VITE_CLERK_FRONTEND_API=${{ vars.STAGING_CLERK_FRONTEND_API }} \
           make docker_build TAG=langflow:staging-$BRANCH_NAME-$COMMIT_ID
 
           docker tag langflow:staging-$BRANCH_NAME-$COMMIT_ID forwardemailforaifirstdesk/langflow:staging-$BRANCH_NAME-$COMMIT_ID
@@ -123,6 +124,7 @@ jobs:
           VITE_AUTO_LOGIN=false \
           VITE_CLERK_AUTH_ENABLED=true \
           VITE_CLERK_PUBLISHABLE_KEY=${{ secrets.PROD_CLERK_PUBLISHABLE_KEY }} \
+          VITE_CLERK_FRONTEND_API=${{ vars.PROD_CLERK_FRONTEND_API }} \
           make docker_build TAG=langflow:prod-$BRANCH_NAME-$COMMIT_ID
         
           docker tag langflow:prod-$BRANCH_NAME-$COMMIT_ID forwardemailforaifirstdesk/langflow:prod-$BRANCH_NAME-$COMMIT_ID


### PR DESCRIPTION
## Summary
- include the Clerk frontend API variable when building staging Docker images
- include the Clerk frontend API variable when building production Docker images

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68edfe2fdc108326bf936ffda7797258