### PR TITLE
Add signed-in user card to organization selection page

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -161,6 +161,53 @@ export default function OrganizationSwitcherPage() {
       .join("") ||
     (primaryEmailAddress ? primaryEmailAddress.charAt(0).toUpperCase() : "?");
 
+  const baseAppearance = {
+    elements: {
+      rootBox: {
+        boxShadow: "none",
+        backgroundColor: "transparent",
+        padding: 0,
+        width: "100%",
+      },
+      organizationList: {
+        width: "100%",
+        gap: "1rem",
+      },
+      organizationList__title: {
+        display: "none",
+      },
+      organizationList__subtitle: {
+        display: "none",
+      },
+      organizationSwitcherTrigger: {
+        borderRadius: "0.75rem",
+        border: "1px solid #e5e7eb",
+        boxShadow: "none",
+      },
+      organizationSwitcherTriggerIcon: {
+        color: "#6366f1",
+      },
+      organizationSwitcherTriggerText: {
+        fontWeight: 600,
+      },
+      organizationSwitcherTriggerSubtitle: {
+        color: "#4b5563",
+      },
+    },
+  };
+
+  const organizationListAppearance = isEnterpriseUser
+    ? {
+        ...baseAppearance,
+        elements: {
+          ...baseAppearance.elements,
+          organizationListCreateOrganizationActionButton: {
+            display: "none",
+          },
+        },
+      }
+    : baseAppearance;
+
   return (
     <div
       style={{
@@ -169,29 +216,54 @@ export default function OrganizationSwitcherPage() {
         alignItems: "center",
         minHeight: "100vh",
         padding: "2rem",
+        background: "linear-gradient(180deg, #f9fafb 0%, #ffffff 100%)",
       }}
     >
       <div
         style={{
+          width: "100%",
+          maxWidth: "32rem",
+          background: "#ffffff",
+          borderRadius: "1.5rem",
+          boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
+          border: "1px solid rgba(99, 102, 241, 0.12)",
+          padding: "2.5rem 2.25rem",
           display: "flex",
           flexDirection: "column",
-          alignItems: "center",
-          gap: "1.5rem",
-          width: "100%",
-          maxWidth: "36rem",
+          gap: "1.75rem",
         }}
       >
+        <div style={{ textAlign: "center" }}>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: "1.5rem",
+              fontWeight: 600,
+              color: "#111827",
+            }}
+          >
+            Choose an organization
+          </h1>
+          <p
+            style={{
+              margin: "0.5rem 0 0",
+              fontSize: "0.95rem",
+              color: "#4b5563",
+            }}
+          >
+            to continue to Visual AI Agents Builder
+          </p>
+        </div>
+
         <div
           style={{
             display: "flex",
             alignItems: "center",
             gap: "1rem",
-            background: "#f9fafb",
-            border: "1px solid #e5e7eb",
-            borderRadius: "0.75rem",
-            padding: "1rem 1.25rem",
-            width: "100%",
-            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+            background: "#f4f5ff",
+            borderRadius: "0.9rem",
+            padding: "0.9rem 1.1rem",
+            border: "1px solid rgba(99, 102, 241, 0.18)",
           }}
         >
           {user?.imageUrl ? (
@@ -203,7 +275,7 @@ export default function OrganizationSwitcherPage() {
                 height: "3rem",
                 borderRadius: "9999px",
                 objectFit: "cover",
-                border: "2px solid #e0e7ff",
+                border: "2px solid rgba(99, 102, 241, 0.35)",
               }}
             />
           ) : (
@@ -231,7 +303,7 @@ export default function OrganizationSwitcherPage() {
                 margin: 0,
                 fontSize: "1rem",
                 fontWeight: 600,
-                color: "#111827",
+                color: "#1f2937",
               }}
             >
               {userDisplayName}
@@ -239,7 +311,7 @@ export default function OrganizationSwitcherPage() {
             {primaryEmailAddress && (
               <p
                 style={{
-                  margin: "0.125rem 0 0",
+                  margin: "0.2rem 0 0",
                   fontSize: "0.875rem",
                   color: "#4b5563",
                 }}
@@ -248,34 +320,22 @@ export default function OrganizationSwitcherPage() {
               </p>
             )}
           </div>
-          <span
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#6366f1",
-              background: "#eef2ff",
-              padding: "0.35rem 0.75rem",
-              borderRadius: "9999px",
-            }}
-          >
-            Select organization
-          </span>
         </div>
 
         {shouldShowEnterpriseEmptyState ? (
           <div
             style={{
-              maxWidth: "32rem",
               textAlign: "center",
               display: "flex",
               flexDirection: "column",
               gap: "0.75rem",
+              color: "#4b5563",
             }}
           >
-            <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+            <h2 style={{ fontSize: "1.25rem", fontWeight: 600, margin: 0 }}>
               You&apos;re signed in with enterprise SSO
-            </h1>
-            <p style={{ color: "#4b5563", lineHeight: 1.5 }}>
+            </h2>
+            <p style={{ lineHeight: 1.5, margin: 0 }}>
               Your account is managed by your organization, so creating new
               organizations is disabled. Please contact your administrator if you
               need a new organization to be set up for you.
@@ -286,17 +346,7 @@ export default function OrganizationSwitcherPage() {
             hidePersonal
             afterCreateOrganizationUrl="/organization?selected=true"
             afterSelectOrganizationUrl="/organization?selected=true"
-            appearance={
-              isEnterpriseUser
-                ? {
-                    elements: {
-                      organizationListCreateOrganizationActionButton: {
-                        display: "none",
-                      },
-                    },
-                  }
-                : undefined
-            }
+            appearance={organizationListAppearance}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- display the logged-in user's avatar, name, and email above the organization list
- provide initials-based fallback styling when the user has no profile image
- retain existing enterprise empty state messaging beneath the new user header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef77f162488326bcfb21d97d7da882