### PR TITLE
Refine organization selection layout

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -310,8 +310,11 @@ export default function OrganizationSwitcherPage() {
                 fontWeight: 600,
                 color: "#1f2937",
                 lineHeight: 1.35,
-                wordBreak: "break-word",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
               }}
+              title={userDisplayName}
             >
               {userDisplayName}
             </p>
@@ -322,8 +325,11 @@ export default function OrganizationSwitcherPage() {
                   fontSize: "0.9rem",
                   color: "#4b5563",
                   lineHeight: 1.4,
-                  wordBreak: "break-word",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
                 }}
+                title={primaryEmailAddress}
               >
                 {primaryEmailAddress}
               </p>


### PR DESCRIPTION
## Summary
- restyle the organization chooser into a single card with the signed-in user header placed inside the widget above the chooser title and list
- hide Clerk’s built-in title and actions with appearance overrides while ensuring long user names or emails no longer overflow from the avatar row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef77f162488326bcfb21d97d7da882