### PR TITLE
Enhance organization switcher UI with user details

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -115,6 +115,22 @@ export default function OrganizationSwitcherPage() {
     null;
   const userDisplayName =
     user?.fullName || user?.username || primaryEmailAddress || "Signed in user";
+  const isEnterpriseUser = Boolean(
+    user?.publicMetadata?.isEnterprise ||
+      user?.publicMetadata?.plan === "enterprise" ||
+      user?.unsafeMetadata?.isEnterprise ||
+      user?.unsafeMetadata?.plan === "enterprise" ||
+      user?.externalAccounts?.some((account) => {
+        const provider = account.provider?.toLowerCase?.();
+        return provider === "saml" || provider === "openid_connect";
+      }) ||
+      user?.externalAccounts?.some(
+        (account) => account.verification?.strategy === "saml",
+      ),
+  );
+  const organizationMemberships = user?.organizationMemberships ?? [];
+  const shouldShowEnterpriseEmptyState =
+    isEnterpriseUser && organizationMemberships.length === 0;
   const userInitials =
     userDisplayName
       .split(/\s+/)


### PR DESCRIPTION
## Summary
- show the current user's avatar, initials fallback, and email on the organization switcher page
- refresh the organization list styling with a card layout and tailored Clerk appearance overrides
- provide an enterprise empty state message when no organizations are available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0b37757388326a548be075ee5534c