### PR TITLE
Add user identity header to organization switcher page

### DIFF
--- a/src/frontend/src/clerk/OrganizationPage.tsx
+++ b/src/frontend/src/clerk/OrganizationPage.tsx
@@ -147,53 +147,175 @@ export default function OrganizationSwitcherPage() {
     return <LoadingPage />;
   }
 
+  const displayName =
+    (user?.fullName && user.fullName.trim()) ||
+    user?.username ||
+    [user?.firstName, user?.lastName].filter(Boolean).join(" ") ||
+    user?.primaryEmailAddress?.emailAddress ||
+    user?.id ||
+    "";
+
+  const emailAddress =
+    user?.primaryEmailAddress?.emailAddress ||
+    user?.emailAddresses?.[0]?.emailAddress ||
+    "";
+
+  const avatarUrl = user?.imageUrl;
+  const initials = (
+    (user?.firstName?.[0] || "") + (user?.lastName?.[0] || user?.firstName?.[1] || "")
+  ).toUpperCase();
+
   return (
     <div
       style={{
         display: "flex",
         justifyContent: "center",
-        alignItems: "center",
+        alignItems: "flex-start",
         minHeight: "100vh",
-        padding: "2rem",
+        padding: "2rem 1.5rem",
+        backgroundColor: "#f8fafc",
       }}
     >
-      {shouldShowEnterpriseEmptyState ? (
-        <div
-          style={{
-            maxWidth: "32rem",
-            textAlign: "center",
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem",
-          }}
-        >
-          <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
-            You&apos;re signed in with enterprise SSO
-          </h1>
-          <p style={{ color: "#4b5563", lineHeight: 1.5 }}>
-            Your account is managed by your organization, so creating new
-            organizations is disabled. Please contact your administrator if you
-            need a new organization to be set up for you.
-          </p>
-        </div>
-      ) : (
-        <OrganizationList
-          hidePersonal
-          afterCreateOrganizationUrl="/organization?selected=true"
-          afterSelectOrganizationUrl="/organization?selected=true"
-          appearance={
-            isEnterpriseUser
-              ? {
-                  elements: {
-                    organizationListCreateOrganizationActionButton: {
-                      display: "none",
-                    },
-                  },
-                }
-              : undefined
-          }
-        />
-      )}
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "38rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1.5rem",
+        }}
+      >
+        {user && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "1rem",
+              padding: "1.5rem",
+              borderRadius: "1.25rem",
+              background:
+                "linear-gradient(135deg, rgba(99,102,241,0.08) 0%, rgba(59,130,246,0.05) 100%)",
+              border: "1px solid rgba(15, 23, 42, 0.08)",
+              boxShadow: "0 18px 45px rgba(15, 23, 42, 0.08)",
+              backdropFilter: "blur(6px)",
+            }}
+          >
+            <div
+              style={{
+                width: "4rem",
+                height: "4rem",
+                borderRadius: "9999px",
+                overflow: "hidden",
+                border: "2px solid rgba(99, 102, 241, 0.35)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background:
+                  "linear-gradient(135deg, rgba(99,102,241,0.16), rgba(129,140,248,0.22))",
+              }}
+            >
+              {avatarUrl ? (
+                <img
+                  src={avatarUrl}
+                  alt={displayName || "Current user"}
+                  style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                />
+              ) : (
+                <span
+                  style={{
+                    color: "#312e81",
+                    fontSize: "1.5rem",
+                    fontWeight: 600,
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  {initials || "US"}
+                </span>
+              )}
+            </div>
+
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: "1.625rem",
+                  fontWeight: 700,
+                  color: "#1e293b",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+                title={displayName}
+              >
+                {displayName}
+              </div>
+              {emailAddress && (
+                <div
+                  style={{
+                    marginTop: "0.35rem",
+                    fontSize: "1rem",
+                    color: "#475569",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                  title={emailAddress}
+                >
+                  {emailAddress}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {shouldShowEnterpriseEmptyState ? (
+          <div
+            style={{
+              maxWidth: "32rem",
+              textAlign: "center",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.75rem",
+              margin: "0 auto",
+            }}
+          >
+            <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+              You&apos;re signed in with enterprise SSO
+            </h1>
+            <p style={{ color: "#4b5563", lineHeight: 1.5 }}>
+              Your account is managed by your organization, so creating new
+              organizations is disabled. Please contact your administrator if
+              you need a new organization to be set up for you.
+            </p>
+          </div>
+        ) : (
+          <div
+            style={{
+              backgroundColor: "var(--clerk-color-background, #ffffff)",
+              borderRadius: "1.25rem",
+              padding: "1.25rem",
+              boxShadow: "0 12px 35px rgba(15, 23, 42, 0.08)",
+              border: "1px solid rgba(15, 23, 42, 0.08)",
+            }}
+          >
+            <OrganizationList
+              hidePersonal
+              afterCreateOrganizationUrl="/organization?selected=true"
+              afterSelectOrganizationUrl="/organization?selected=true"
+              appearance={
+                isEnterpriseUser
+                  ? {
+                      elements: {
+                        organizationListCreateOrganizationActionButton: {
+                          display: "none",
+                        },
+                      },
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a personalized user identity card above the Clerk organization list
- display the current member avatar, name, and email with ellipsis and tooltips to prevent overflow
- wrap the organization list in a styled container to align the layout with the Clerk theme across breakpoints
- ensure the user identity card renders even for enterprise SSO members without organizations

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68f1107b31408326878cc31ecc209670