### PR TITLE
Lazy load authenticated shell for landing bundle

### DIFF
--- a/src/frontend/src/pages/AppWrapperPage/components/AuthenticatedAppShell.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/components/AuthenticatedAppShell.tsx
@@ -1,0 +1,33 @@
+import AlertDisplayArea from "@/alerts/displayArea";
+import CrashErrorComponent from "@/components/common/crashErrorComponent";
+import { ErrorBoundary } from "react-error-boundary";
+import { Outlet } from "react-router-dom";
+import { GenericErrorComponent } from "./GenericErrorComponent";
+import { useHealthCheck } from "../hooks/use-health-check";
+
+export default function AuthenticatedAppShell() {
+  const { healthCheckTimeout, fetchingHealth, refetch } = useHealthCheck();
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <ErrorBoundary
+        onReset={() => {
+          // any reset function
+        }}
+        FallbackComponent={CrashErrorComponent}
+      >
+        <>
+          <GenericErrorComponent
+            healthCheckTimeout={healthCheckTimeout}
+            fetching={fetchingHealth}
+            retry={refetch}
+          />
+          <Outlet />
+        </>
+      </ErrorBoundary>
+      <div className="app-div">
+        <AlertDisplayArea />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/AppWrapperPage/index.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/index.tsx
@@ -1,16 +1,14 @@
-import AlertDisplayArea from "@/alerts/displayArea";
-import CrashErrorComponent from "@/components/common/crashErrorComponent";
-import { ErrorBoundary } from "react-error-boundary";
-import useAuthStore from "@/stores/authStore";
-import { Outlet , useLocation } from "react-router-dom";
+import { Suspense, lazy } from "react";
+import { useLocation } from "react-router-dom";
 import Landing from "../LandingPage";
-import { GenericErrorComponent } from "./components/GenericErrorComponent";
-import { useHealthCheck } from "./hooks/use-health-check";
+import { LoadingPage } from "../LoadingPage";
+
+const AuthenticatedAppShell = lazy(
+  () => import("./components/AuthenticatedAppShell"),
+);
 
 export function AppWrapperPage() {
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { pathname } = useLocation();
-  const { healthCheckTimeout, fetchingHealth, refetch } = useHealthCheck();
 
   // Render the marketing landing page when visitor hits the root route
   // regardless of authentication status
@@ -19,25 +17,8 @@ export function AppWrapperPage() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <ErrorBoundary
-        onReset={() => {
-          // any reset function
-        }}
-        FallbackComponent={CrashErrorComponent}
-      >
-        <>
-          <GenericErrorComponent
-            healthCheckTimeout={healthCheckTimeout}
-            fetching={fetchingHealth}
-            retry={refetch}
-          />
-          <Outlet />
-        </>
-      </ErrorBoundary>
-      <div className="app-div">
-        <AlertDisplayArea />
-      </div>
-    </div>
+    <Suspense fallback={<LoadingPage />}>
+      <AuthenticatedAppShell />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- defer loading of the authenticated application shell while the landing page is active
- move the health-check and alert boundary logic into a lazily loaded component to keep heavy flow dependencies out of the initial bundle

## Testing
- not run (vite build did not complete within the time limits of the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_69008e9ede2083268e7b4f85f3afde0c