### PR TITLE
Refactor landing page for faster initial render

### DIFF
--- a/docs/landing-page-fast-load.md
+++ b/docs/landing-page-fast-load.md
@@ -1,0 +1,19 @@
+# Landing page fast-loading strategy
+
+The landing page now renders the hero section immediately and delays heavier UI until the browser has time to download the remaining chunk.
+
+## Key changes
+
+- **Hero-first render:** The navigation, hero headline, and supporting call-to-action stay in the root component so they are part of the initial bundle. The hero image is marked with `fetchPriority="high"` and `decoding="async"` so the browser fetches it right away without blocking layout.
+- **Deferred content loading:** Everything below the hero (feature lists, pricing, blog teaser, and footer) moved into `DeferredSections.tsx`. The landing page lazily imports this module inside a `Suspense` boundary after the browser becomes idle (`requestIdleCallback` with a `setTimeout` fallback). The hero renders instantly while the rest streams in.
+- **Lean dependencies:** The page no longer depends on `framer-motion`. The animated arrow beside the dashboard button is now a lightweight CSS keyframe animation, and the mobile menu uses simple conditionals.
+- **Media optimizations:** Non-critical images in deferred sections use `loading="lazy"` and `decoding="async"` so they download after the hero is visible.
+
+## How to work with it
+
+1. Update content in the hero section directly in `src/frontend/src/pages/LandingPage/index.tsx`.
+2. Add or edit sections that can be deferred in `src/frontend/src/pages/LandingPage/DeferredSections.tsx`. Anything exported from this file loads after the hero by default.
+3. If you add another critical-above-the-fold component, keep it in `index.tsx` so it stays in the first paint. Non-critical additions should go to the deferred module.
+4. CSS rules specific to the hero (like the arrow animation) live in `src/frontend/src/App.css`. Tailwind utility classes still cover most styling.
+
+This setup keeps the first render very small, letting visitors see the hero instantly while the rest of the page hydrates in the background.

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -200,6 +200,20 @@ code {
   margin: 0;
 }
 
+.landing-arrow {
+  animation: landing-arrow 1.6s ease-in-out infinite;
+}
+
+@keyframes landing-arrow {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(4px);
+  }
+}
+
 .ag-large-text-input.ag-text-area.ag-input-field {
   background-color: hsl(var(--background)) !important;
 }

--- a/src/frontend/src/pages/LandingPage/DeferredSections.tsx
+++ b/src/frontend/src/pages/LandingPage/DeferredSections.tsx
@@ -1,0 +1,329 @@
+import type { JSX } from "react";
+
+import { CheckIcon } from "./icons";
+
+const FEATURE_CARDS = [
+  {
+    title: "Visual Flow Builder",
+    desc: "Build and connect components, agents, memory, tools & prompts via drag-drop to design complex AI workflows without writing boilerplate code.",
+  },
+  {
+    title: "Wide AI Stack Support",
+    desc: "Use any leading LLM or vector database; support for custom components. Cloud or local deployment options including GPU acceleration.",
+  },
+  {
+    title: "Real-Time Testing & Deployment",
+    desc: "Test flows in real time using playground; deploy flows as APIs or MCP servers; version control and inference options.",
+  },
+] as const;
+
+const HOW_IT_WORKS = [
+  {
+    step: "01",
+    title: "Design Flow",
+    desc: "Choose from prebuilt templates or start fresh: drag & drop components to build agents, tools, memory, and LLM calls.",
+  },
+  {
+    step: "02",
+    title: "Test & Tune",
+    desc: "Use live playground; adjust prompts, test agents; monitor performance and debug before deploying live.",
+  },
+  {
+    step: "03",
+    title: "Deploy Securely",
+    desc: "Deploy to enterprise cloud or on-prem; configure SSO, isolate data per-tenant; audit logs & compliance baked-in.",
+  },
+] as const;
+
+const ENTERPRISE_FEATURES = [
+  {
+    title: "Organization Tenancies & RBAC",
+    desc: "Multiple teams under your account; fine-grained permissions; keep workspaces separated by team or business unit.",
+  },
+  {
+    title: "Single Sign-On (SSO) & Audit Logs",
+    desc: "Integrate SSO with your identity provider, get logs & user activity tracked for compliance & security reviews.",
+  },
+  {
+    title: "Data Isolation & Security by Design",
+    desc: "Isolated data per tenant; encrypted at rest & in transit; cloud or on-prem options; compliance support (GDPR, etc.).",
+  },
+] as const;
+
+const SOCIAL_PROOF = [
+  { k: "80%+", v: "reduction in development time" },
+  { k: "Hundreds", v: "of LLMs & vector DBs supported" },
+  { k: "Enterprise Ready", v: "SSO · Tenancies · Data Isolation" },
+] as const;
+
+const PRICING_FEATURES = [
+  "Unlimited public flows",
+  "Team seats & organization tenancies",
+  "Enterprise support & SLA",
+] as const;
+
+export default function DeferredSections(): JSX.Element {
+  return (
+    <>
+      <section id="features" className="mx-auto max-w-7xl px-4 py-20">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="text-2xl font-semibold">Features</h2>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {FEATURE_CARDS.map((feature) => (
+            <div
+              key={feature.title}
+              className="rounded-2xl border border-white/10 bg-[#0f1217] p-6"
+            >
+              <h3 className="text-lg font-semibold">{feature.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{feature.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="how" className="mx-auto max-w-7xl px-4 py-20">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="text-2xl font-semibold">How it Works</h2>
+          <a href="#docs" className="text-sm text-white/70 hover:text-white">
+            Read the Docs →
+          </a>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {HOW_IT_WORKS.map((step) => (
+            <div
+              key={step.title}
+              className="relative rounded-2xl border border-white/10 p-6"
+            >
+              <span className="absolute -top-3 left-6 rounded-full border border-white/15 bg-[#0f1217] px-3 py-1 text-xs text-white/70">
+                {step.step}
+              </span>
+              <h3 className="mt-2 text-lg font-semibold">{step.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{step.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="enterprise"
+        className="mx-auto max-w-7xl rounded-2xl border border-white/10 bg-[#0f1217] px-4 py-20"
+      >
+        <h2 className="text-center text-2xl font-semibold">
+          Enterprise-grade Capabilities
+        </h2>
+        <p className="mx-auto mt-3 max-w-2xl text-center text-white/70">
+          Everything you need for teams, security, compliance, and scale.
+        </p>
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          {ENTERPRISE_FEATURES.map((enterprise) => (
+            <div
+              key={enterprise.title}
+              className="rounded-2xl border border-white/10 bg-[#0f1217] p-6"
+            >
+              <h3 className="text-lg font-semibold">{enterprise.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{enterprise.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-20">
+        <div className="grid gap-6 rounded-2xl border border-white/10 bg-[#0f1217] p-8 md:grid-cols-3">
+          {SOCIAL_PROOF.map((item) => (
+            <div key={item.k} className="text-center">
+              <div className="text-4xl font-semibold tracking-tight">
+                {item.k}
+              </div>
+              <div className="mt-1 text-sm text-white/70">{item.v}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="video" className="mx-auto max-w-7xl px-4 py-20">
+        <div className="grid items-center gap-8 md:grid-cols-2">
+          <div>
+            <h2 className="text-2xl font-semibold">See it In Action</h2>
+            <p className="mt-3 max-w-prose text-white/70">
+              Watch our walkthrough of the visual flow builder, enterprise
+              features, and how quickly you can build & deploy an AI agent.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-white/70">
+              <div className="flex items-center gap-2">
+                <CheckIcon className="h-4 w-4" />
+                Local & Cloud Deployment
+              </div>
+              <div className="flex items-center gap-2">
+                <CheckIcon className="h-4 w-4" />
+                Observability & Logging
+              </div>
+              <div className="flex items-center gap-2">
+                <CheckIcon className="h-4 w-4" />
+                Compliance & Security Controls
+              </div>
+            </div>
+          </div>
+          <div className="aspect-video w-full overflow-hidden rounded-2xl border border-white/10 bg-[#0f1217]">
+            <img
+              src="/images/demo-walkthrough.png"
+              alt="Demo video walkthrough"
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section id="pricing" className="mx-auto max-w-7xl px-4 py-20">
+        <div className="rounded-2xl border border-white/10 bg-[#0f1217] p-8">
+          <div className="grid gap-10 md:grid-cols-2">
+            <div>
+              <h2 className="text-2xl font-semibold">
+                Fair, Transparent Pricing
+              </h2>
+              <p className="mt-3 text-white/70">
+                Free (for developers) plus paid plans for teams and enterprise
+                with full security & support.
+              </p>
+              <ul className="mt-6 space-y-2 text-sm text-white/80">
+                {PRICING_FEATURES.map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <CheckIcon className="h-4 w-4" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
+                <div className="text-sm text-white/60">Starter</div>
+                <div className="mt-2 text-3xl font-semibold">Free</div>
+                <p className="mt-2 text-sm text-white/70">
+                  For personal projects, hobbyists. All core features except
+                  enterprise.
+                </p>
+                <a
+                  href="#signup"
+                  className="mt-4 inline-block rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900"
+                >
+                  Get Started Free
+                </a>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
+                <div className="text-sm text-white/60">Enterprise</div>
+                <div className="mt-2 text-3xl font-semibold">Contact Us</div>
+                <p className="mt-2 text-sm text-white/70">
+                  Includes SSO, data isolation, custom deployment, dedicated
+                  support & SLAs.
+                </p>
+                <a
+                  href="#contact"
+                  className="mt-4 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
+                >
+                  Contact Sales
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="blog" className="mx-auto max-w-7xl px-4 py-14">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="text-2xl font-semibold">Latest from the Blog</h2>
+          <a
+            href="#all-posts"
+            className="text-sm text-white/70 hover:text-white"
+          >
+            View all →
+          </a>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {[1, 2, 3].map((item) => (
+            <article
+              key={item}
+              className="rounded-2xl border border-white/10 bg-[#0f1217] p-5"
+            >
+              <div className="aspect-[16/9] w-full rounded-lg bg-white/5" />
+              <h3 className="mt-4 text-lg font-semibold">
+                Blog post title {item}
+              </h3>
+              <p className="mt-1 text-sm text-white/70">
+                Insights, tutorials & best practices on AI workflows, agents,
+                and security.
+              </p>
+              <a
+                href="#"
+                className="mt-4 inline-block text-sm text-white/80 hover:text-white"
+              >
+                Read more →
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <footer className="border-t border-white/10">
+        <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 md:grid-cols-4">
+          <div>
+            <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-teal-500 font-bold">
+              VA
+            </div>
+            <p className="mt-3 max-w-xs text-sm text-white/70">
+              Build, deploy and scale AI agents enterprise-securely, powered by
+              Langflow.
+            </p>
+          </div>
+          <div>
+            <div className="text-sm font-semibold">Product</div>
+            <ul className="mt-3 space-y-2 text-sm text-white/70">
+              <li>
+                <a href="#features">Features</a>
+              </li>
+              <li>
+                <a href="#how">How it Works</a>
+              </li>
+              <li>
+                <a href="#enterprise">Enterprise</a>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="text-sm font-semibold">Support</div>
+            <ul className="mt-3 space-y-2 text-sm text-white/70">
+              <li>
+                <a href="#docs">Docs</a>
+              </li>
+              <li>
+                <a href="#blog">Blog</a>
+              </li>
+              <li>
+                <a href="#contact">Contact</a>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="text-sm font-semibold">Legal & Company</div>
+            <ul className="mt-3 space-y-2 text-sm text-white/70">
+              <li>
+                <a href="#privacy">Privacy Policy</a>
+              </li>
+              <li>
+                <a href="#terms">Terms of Service</a>
+              </li>
+              <li>
+                <a href="#careers">Careers</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div className="border-t border-white/10 py-6 text-center text-xs text-white/60">
+          © {new Date().getFullYear()} Visual AI Agents Builder. All rights
+          reserved.
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/src/frontend/src/pages/LandingPage/icons.tsx
+++ b/src/frontend/src/pages/LandingPage/icons.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from "react";
+
+export function CheckIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="M20.285 6.709a1 1 0 0 1 0 1.414l-9.192 9.192a1 1 0 0 1-1.414 0L3.715 11.55a1 1 0 0 1 1.414-1.415l5.136 5.136 8.485-8.485a1 1 0 0 1 1.535-.077z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export function PlayIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path d="M8 5v14l11-7z" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/frontend/src/pages/LandingPage/index.tsx
+++ b/src/frontend/src/pages/LandingPage/index.tsx
@@ -1,54 +1,116 @@
-import { motion, AnimatePresence } from "framer-motion";
 import type { JSX, SVGProps } from "react";
-import VisualWorkflow from "../../assets/VisualWorkflow.png";
-import { useState } from "react";
-import useAuthStore from "@/stores/authStore";
-import { useLogout } from "@/clerk/auth";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useLogout } from "@/clerk/auth";
+import useAuthStore from "@/stores/authStore";
 
-function CheckIcon(props: SVGProps<SVGSVGElement>) {
+import VisualWorkflow from "../../assets/VisualWorkflow.png";
+import { CheckIcon, PlayIcon } from "./icons";
+
+const LazyDeferredSections = lazy(async () => import("./DeferredSections"));
+
+type ExtendedWindow = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+function ArrowIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={["landing-arrow", className].filter(Boolean).join(" ")}
+      {...props}
+    >
       <path
-        d="M20.285 6.709a1 1 0 0 1 0 1.414l-9.192 9.192a1 1 0 0 1-1.414 0L3.715 11.55a1 1 0 0 1 1.414-1.415l5.136 5.136 8.485-8.485a1 1 0 0 1 1.535-.077z"
+        d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
         fill="currentColor"
       />
     </svg>
   );
 }
 
-function PlayIcon(props: SVGProps<SVGSVGElement>) {
+function DeferredSkeleton(): JSX.Element {
   return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path d="M8 5v14l11-7z" fill="currentColor" />
-    </svg>
+    <div className="mx-auto max-w-7xl px-4 py-20">
+      <div className="h-48 rounded-2xl border border-white/10 bg-white/5" />
+    </div>
   );
 }
 
-function AnimatedArrowIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <motion.svg 
-      viewBox="0 0 24 24" 
-      aria-hidden="true" 
-      {...props}
-      animate={{ x: [0, 4, 0] }}
-      transition={{ 
-        duration: 1.5, 
-        repeat: Infinity, 
-        ease: "easeInOut" 
-      }}
-    >
-      <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z" fill="currentColor" />
-    </motion.svg>
-  );
-}
+const NAV_LINKS = [
+  { href: "#features", label: "Features" },
+  { href: "#how", label: "How it Works" },
+  { href: "#enterprise", label: "Enterprise" },
+  { href: "#pricing", label: "Pricing" },
+] as const;
 
 export default function Landing(): JSX.Element {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [shouldRenderDeferred, setShouldRenderDeferred] = useState(false);
+
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { mutate: logout } = useLogout();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let cancelled = false;
+    const showDeferred = () => {
+      if (!cancelled) {
+        setShouldRenderDeferred(true);
+      }
+    };
+
+    const extendedWindow = window as ExtendedWindow;
+
+    if (extendedWindow.requestIdleCallback) {
+      const idleId = extendedWindow.requestIdleCallback(showDeferred);
+      return () => {
+        cancelled = true;
+        if (extendedWindow.cancelIdleCallback) {
+          extendedWindow.cancelIdleCallback(idleId);
+        }
+      };
+    }
+
+    const timeoutId = window.setTimeout(showDeferred, 0);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+
+    if (isMenuOpen) {
+      body.style.overflow = "hidden";
+      return () => {
+        body.style.overflow = previousOverflow;
+      };
+    }
+
+    body.style.overflow = previousOverflow;
+
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [isMenuOpen]);
 
   const handleLogout = () => {
     logout();
@@ -57,91 +119,81 @@ export default function Landing(): JSX.Element {
   const handleDashboardClick = () => {
     navigate("/flows");
   };
+
+  const closeMenu = () => setIsMenuOpen(false);
+
   return (
-    <div className="h-screen overflow-y-auto bg-[#0f1217] text-white">
-      {/* Background accents */}
+    <div className="min-h-screen overflow-y-auto bg-[#0f1217] text-white">
       <div className="pointer-events-none fixed inset-0 -z-10">
-        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-gradient-to-br from-teal-500 to-blue-500/20 blur-3xl" />
+        <div className="absolute -left-24 -top-24 h-72 w-72 rounded-full bg-gradient-to-br from-teal-500 to-blue-500/20 blur-3xl" />
         <div className="absolute -bottom-24 -right-24 h-72 w-72 rounded-full bg-gradient-to-br from-purple-500 to-pink-500/20 blur-3xl" />
       </div>
 
-      {/* Navbar */}
       <header className="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-neutral-900/60">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-          {/* Logo and responsive title */}
           <div className="flex items-center gap-2">
             <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-teal-500 font-bold">
               VA
             </span>
-            {/* Short title for mobile view with no-wrap */}
             <span className="whitespace-nowrap text-sm font-semibold tracking-wide text-white/90 md:hidden">
               Visual AI Agents Builder
             </span>
-            {/* Full title for desktop view */}
             <span className="hidden whitespace-nowrap text-sm font-semibold tracking-wide text-white/90 md:inline">
               Visual AI Agents Builder
             </span>
           </div>
 
-          {/* Desktop Nav (no changes needed) */}
           <nav className="hidden items-center gap-8 md:flex">
-            <a className="text-white/70 hover:text-white" href="#features">
-              Features
-            </a>
-            <a className="text-white/70 hover:text-white" href="#how">
-              How it Works
-            </a>
-            <a className="text-white/70 hover:text-white" href="#enterprise">
-              Enterprise
-            </a>
-            <a className="text-white/70 hover:text-white" href="#pricing">
-              Pricing
-            </a>
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                className="text-white/70 hover:text-white"
+                href={link.href}
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
 
-          {/* Right side buttons */}
           <div className="flex items-center gap-3">
-            {/* Mobile Menu Button */}
             <button
-              className="md:hidden p-2 rounded-lg hover:bg-white/10"
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              type="button"
+              className="rounded-lg p-2 hover:bg-white/10 md:hidden"
+              aria-label={isMenuOpen ? "Close navigation" : "Open navigation"}
+              aria-expanded={isMenuOpen}
+              onClick={() => setIsMenuOpen((open) => !open)}
             >
               <div className="space-y-1">
-                <span className="block h-0.5 w-6 bg-white"></span>
-                <span className="block h-0.5 w-6 bg-white"></span>
-                <span className="block h-0.5 w-6 bg-white"></span>
+                <span className="block h-0.5 w-6 bg-white" />
+                <span className="block h-0.5 w-6 bg-white" />
+                <span className="block h-0.5 w-6 bg-white" />
               </div>
             </button>
 
-            {/* Conditional buttons based on authentication */}
             {isAuthenticated ? (
               <>
-                {/* Sign Out button (replaces Book a Demo when authenticated) */}
                 <button
                   onClick={handleLogout}
-                  className="hidden md:inline-block rounded-xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:opacity-90"
+                  className="hidden rounded-xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:opacity-90 md:inline-block"
                 >
                   Sign Out
                 </button>
-                {/* Dashboard button with animated arrow (replaces Log in when authenticated) */}
                 <button
                   onClick={handleDashboardClick}
-                  className="whitespace-nowrap rounded-xl bg-gradient-to-r from-teal-500 to-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 flex items-center gap-2"
+                  className="flex items-center gap-2 whitespace-nowrap rounded-xl bg-gradient-to-r from-teal-500 to-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
                 >
                   Dashboard
-                  <AnimatedArrowIcon className="h-4 w-4" />
+                  <ArrowIcon className="h-4 w-4" />
                 </button>
               </>
             ) : (
               <>
-                {/* Book a Demo (shown when unauthenticated) */}
                 <a
                   href="#demo"
-                  className="hidden md:inline-block rounded-xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:opacity-90"
+                  className="hidden rounded-xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:opacity-90 md:inline-block"
                 >
                   Book a Demo
                 </a>
-                {/* Log in (shown when unauthenticated) */}
                 <a
                   href="/login"
                   className="whitespace-nowrap rounded-xl bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:opacity-90"
@@ -154,73 +206,54 @@ export default function Landing(): JSX.Element {
         </div>
       </header>
 
-      <AnimatePresence>
-        {isMenuOpen && (
-        <motion.div
-          initial={{ opacity: 0, x: "100%" }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: "100%" }}
-          transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-50 flex flex-col items-center justify-start bg-gradient-to-b from-[#0f1217] via-50% via-[#0f1217] to-transparent px-6 pt-24 backdrop-blur-md"
-        >
-        <button
-          className="absolute top-4 right-4 p-2 rounded-lg hover:bg-white/10"
-          onClick={() => setIsMenuOpen(false)}
-        >
-          ✕
-        </button>
-        <nav className="space-y-6 text-center text-x">
-          <a 
-            className="block text-white/90 hover:text-white" 
-            href="#features"
-            onClick={() => setIsMenuOpen(false)}
+      {isMenuOpen ? (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-start bg-gradient-to-b from-[#0f1217] via-[#0f1217]/95 to-transparent px-6 pt-24 backdrop-blur-md">
+          <button
+            type="button"
+            className="absolute right-4 top-4 rounded-lg p-2 hover:bg-white/10"
+            onClick={closeMenu}
+            aria-label="Close navigation"
           >
-            Features
-          </a>
-          <a 
-            className="block text-white/90 hover:text-white" 
-            href="#how"
-            onClick={() => setIsMenuOpen(false)}
-          >
-            How it Works
-          </a>
-          <a 
-            className="block text-white/90 hover:text-white" 
-            href="#enterprise"
-            onClick={() => setIsMenuOpen(false)}
-          >
-            Enterprise
-          </a>
-          <a 
-            className="block text-white/90 hover:text-white" 
-            href="#pricing"
-            onClick={() => setIsMenuOpen(false)}
-          >
-            Pricing
-          </a>
-        </nav>
-        </motion.div>
-        )}
-      </AnimatePresence>
+            ✕
+          </button>
+          <nav className="space-y-6 text-center text-base">
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                className="block text-white/90 hover:text-white"
+                href={link.href}
+                onClick={closeMenu}
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+      ) : null}
 
-      {/* Hero */}
       <section className="relative mx-auto max-w-7xl px-4 pb-12 pt-20 sm:pt-28">
-        
         <div className="grid items-center gap-10 md:grid-cols-2">
-          
           <div>
             <p className="mb-4 inline-block rounded-full border border-white/10 px-3 py-1 text-xs text-white/70">
               Powered by Langflow + Enterprise Security
             </p>
-            <h1 className="text-3xl font-semibold tracking-tight sm:text-5xl" data-testid="hero-headline">
+            <h1
+              className="text-3xl font-semibold tracking-tight sm:text-5xl"
+              data-testid="hero-headline"
+            >
               Build AI Agents in Minutes.
               <br />
-              <span className="block bg-gradient-to-r from-teal-400 to-blue-400 bg-clip-text text-transparent pb-1">
+              <span className="block bg-gradient-to-r from-teal-400 to-blue-400 bg-clip-text pb-1 text-transparent">
                 Drag, Drop & Deploy Securely.
               </span>
             </h1>
-            <p className="mt-5 max-w-xl text-white/70" data-testid="hero-subcopy">
-              Visual AI Agents Builder brings you a no-/low-code interface on top of Langflow, with enterprise-grade tenancies, SSO, data isolation, audit logs & security out-of-the-box.
+            <p
+              className="mt-5 max-w-xl text-white/70"
+              data-testid="hero-subcopy"
+            >
+              Visual AI Agents Builder brings you a no-/low-code interface on
+              top of Langflow, with enterprise-grade tenancies, SSO, data
+              isolation, audit logs & security out-of-the-box.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <a
@@ -238,306 +271,36 @@ export default function Landing(): JSX.Element {
                 <PlayIcon className="h-4 w-4" /> Watch the Demo
               </a>
             </div>
-            <div className="mt-6 flex items-center gap-6 text-xs text-white/60">
+            <div className="mt-6 flex flex-wrap items-center gap-6 text-xs text-white/60">
               <div className="flex items-center gap-2">
-                <CheckIcon className="h-4 w-4" />Visual drag-and-drop flows
+                <CheckIcon className="h-4 w-4" />
+                Visual drag-and-drop flows
               </div>
               <div className="flex items-center gap-2">
-                <CheckIcon className="h-4 w-4" />Deploy as API / MCP tools
+                <CheckIcon className="h-4 w-4" />
+                Deploy as API / MCP tools
               </div>
             </div>
           </div>
           <div className="relative">
-            {/* Placeholder for graphic/image of agent flow in visual builder */}
             <img
               src={VisualWorkflow}
               alt="Visual workflow builder screenshot"
-              className="w-full h-auto rounded-2xl border border-black/5 object-cover"
+              loading="eager"
+              decoding="async"
+              fetchPriority="high"
+              className="h-auto w-full rounded-2xl border border-black/5 object-cover"
             />
             <div className="absolute -bottom-4 -right-4 hidden h-40 w-40 rounded-full bg-teal-500/20 blur-2xl md:block" />
           </div>
         </div>
       </section>
 
-      {/* Features / Value Props */}
-      <section id="features" className="mx-auto max-w-7xl px-4 py-20">
-        <div className="mb-8 flex items-center justify-between">
-          <h2 className="text-2xl font-semibold">Features</h2>
-        </div>
-        <div className="grid gap-6 md:grid-cols-3">
-          {[
-            {
-              title: "Visual Flow Builder",
-              desc: "Build and connect components, agents, memory, tools & prompts via drag-drop to design complex AI workflows without writing boilerplate code.",
-            },
-            {
-              title: "Wide AI Stack Support",
-              desc: "Use any leading LLM or vector database; support for custom components. Cloud or local deployment options including GPU acceleration.",
-            },
-            {
-              title: "Real-Time Testing & Deployment",
-              desc: "Test flows in real time using playground; deploy flows as APIs or MCP servers; version control and inference options.",
-            },
-          ].map((feature) => (
-            <div key={feature.title} className="rounded-2xl border border-white/10 bg-[#0f1217] p-6">
-              <h3 className="text-lg font-semibold">{feature.title}</h3>
-              <p className="mt-2 text-sm text-white/70">{feature.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* How it works */}
-      <section id="how" className="mx-auto max-w-7xl px-4 py-20">
-        <div className="mb-8 flex items-center justify-between">
-          <h2 className="text-2xl font-semibold">How it Works</h2>
-          <a href="#docs" className="text-sm text-white/70 hover:text-white">
-            Read the Docs →
-          </a>
-        </div>
-        <div className="grid gap-6 md:grid-cols-3">
-          {[
-            {
-              step: "01",
-              title: "Design Flow",
-              desc: "Choose from prebuilt templates or start fresh: drag & drop components to build agents, tools, memory, and LLM calls.",
-            },
-            {
-              step: "02",
-              title: "Test & Tune",
-              desc: "Use live playground; adjust prompts, test agents; monitor performance and debug before deploying live.",
-            },
-            {
-              step: "03",
-              title: "Deploy Securely",
-              desc: "Deploy to enterprise cloud or on-prem; configure SSO, isolate data per-tenant; audit logs & compliance baked-in.",
-            },
-          ].map((step) => (
-            <div key={step.title} className="relative rounded-2xl border border-white/10 p-6">
-              <span className="absolute -top-3 left-6 rounded-full border border-white/15 bg-[#0f1217] px-3 py-1 text-xs text-white/70">
-                {step.step}
-              </span>
-              <h3 className="mt-2 text-lg font-semibold">{step.title}</h3>
-              <p className="mt-2 text-sm text-white/70">{step.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Enterprise / Unique Features */}
-      <section
-        id="enterprise"
-        className="mx-auto max-w-7xl rounded-2xl border border-white/10 bg-[#0f1217] px-4 py-20"
-      >
-        <h2 className="text-2xl font-semibold text-center">Enterprise-grade Capabilities</h2>
-        <p className="mx-auto mt-3 max-w-2xl text-center text-white/70">
-          Everything you need for teams, security, compliance, and scale.
-        </p>
-        <div className="mt-8 grid gap-6 md:grid-cols-3">
-          {[
-            {
-              title: "Organization Tenancies & RBAC",
-              desc: "Multiple teams under your account; fine-grained permissions; keep workspaces separated by team or business unit.",
-            },
-            {
-              title: "Single Sign-On (SSO) & Audit Logs",
-              desc: "Integrate SSO with your identity provider, get logs & user activity tracked for compliance & security reviews.",
-            },
-            {
-              title: "Data Isolation & Security by Design",
-              desc: "Isolated data per tenant; encrypted at rest & in transit; cloud or on-prem options; compliance support (GDPR, etc.).",
-            },
-          ].map((enterprise) => (
-            <div key={enterprise.title} className="rounded-2xl border border-white/10 bg-[#0f1217] p-6">
-              <h3 className="text-lg font-semibold">{enterprise.title}</h3>
-              <p className="mt-2 text-sm text-white/70">{enterprise.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Stats & Social Proof */}
-      <section className="mx-auto max-w-7xl px-4 py-20">
-        <div className="grid gap-6 rounded-2xl border border-white/10 bg-[#0f1217] p-8 md:grid-cols-3">
-          {[
-            { k: "80%+", v: "reduction in development time" },
-            { k: "Hundreds", v: "of LLMs & vector DBs supported" },
-            { k: "Enterprise Ready", v: "SSO · Tenancies · Data Isolation" },
-          ].map((item) => (
-            <div key={item.k} className="text-center">
-              <div className="text-4xl font-semibold tracking-tight">{item.k}</div>
-              <div className="mt-1 text-sm text-white/70">{item.v}</div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Video / Demo */}
-      <section id="video" className="mx-auto max-w-7xl px-4 py-20">
-        <div className="grid items-center gap-8 md:grid-cols-2">
-          <div>
-            <h2 className="text-2xl font-semibold">See it In Action</h2>
-            <p className="mt-3 max-w-prose text-white/70">
-              Watch our walkthrough of the visual flow builder, enterprise features, and how quickly you can build & deploy an AI agent.
-            </p>
-            <div className="mt-6 flex items-center gap-3 text-sm text-white/70">
-              <div className="flex items-center gap-2">
-                <CheckIcon className="h-4 w-4" />Local & Cloud Deployment
-              </div>
-              <div className="flex items-center gap-2">
-                <CheckIcon className="h-4 w-4" />Observability & Logging
-              </div>
-              <div className="flex items-center gap-2">
-                <CheckIcon className="h-4 w-4" />Compliance & Security Controls
-              </div>
-            </div>
-          </div>
-          <div className="aspect-video w-full overflow-hidden rounded-2xl border border-white/10 bg-[#0f1217]">
-            {/* Replace with your video embed or demo gif */}
-            <img
-              src="/images/demo-walkthrough.png"
-              alt="Demo video walkthrough"
-              className="h-full w-full object-cover"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Pricing teaser */}
-      <section id="pricing" className="mx-auto max-w-7xl px-4 py-20">
-        <div className="rounded-2xl border border-white/10 bg-[#0f1217] p-8">
-          <div className="grid gap-10 md:grid-cols-2">
-            <div>
-              <h2 className="text-2xl font-semibold">Fair, Transparent Pricing</h2>
-              <p className="mt-3 text-white/70">
-                Free (for developers) plus paid plans for teams and enterprise with full security & support.
-              </p>
-              <ul className="mt-6 space-y-2 text-sm text-white/80">
-                <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Unlimited public flows
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Team seats & organization tenancies
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Enterprise support & SLA
-                </li>
-              </ul>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
-                <div className="text-sm text-white/60">Starter</div>
-                <div className="mt-2 text-3xl font-semibold">Free</div>
-                <p className="mt-2 text-sm text-white/70">
-                  For personal projects, hobbyists. All core features except enterprise.
-                </p>
-                <a
-                  href="#signup"
-                  className="mt-4 inline-block rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900"
-                >
-                  Get Started Free
-                </a>
-              </div>
-              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
-                <div className="text-sm text-white/60">Enterprise</div>
-                <div className="mt-2 text-3xl font-semibold">Contact Us</div>
-                <p className="mt-2 text-sm text-white/70">
-                  Includes SSO, data isolation, custom deployment, dedicated support & SLAs.
-                </p>
-                <a
-                  href="#contact"
-                  className="mt-4 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
-                >
-                  Contact Sales
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Blog / Resources Teaser */}
-      <section id="blog" className="mx-auto max-w-7xl px-4 py-14">
-        <div className="mb-8 flex items-center justify-between">
-          <h2 className="text-2xl font-semibold">Latest from the Blog</h2>
-          <a href="#all-posts" className="text-sm text-white/70 hover:text-white">
-            View all →
-          </a>
-        </div>
-        <div className="grid gap-6 md:grid-cols-3">
-          {[1, 2, 3].map((item) => (
-            <article key={item} className="rounded-2xl border border-white/10 bg-[#0f1217] p-5">
-              <div className="aspect-[16/9] w-full rounded-lg bg-white/5" />
-              <h3 className="mt-4 text-lg font-semibold">Blog post title {item}</h3>
-              <p className="mt-1 text-sm text-white/70">
-                Insights, tutorials & best practices on AI workflows, agents, and security.
-              </p>
-              <a href="#" className="mt-4 inline-block text-sm text-white/80 hover:text-white">
-                Read more →
-              </a>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="border-t border-white/10">
-        <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 md:grid-cols-4">
-          <div>
-            <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-teal-500 font-bold">
-              VA
-            </div>
-            <p className="mt-3 max-w-xs text-sm text-white/70">
-              Build, deploy and scale AI agents enterprise-securely, powered by Langflow.
-            </p>
-          </div>
-          <div>
-            <div className="text-sm font-semibold">Product</div>
-            <ul className="mt-3 space-y-2 text-sm text-white/70">
-              <li>
-                <a href="#features">Features</a>
-              </li>
-              <li>
-                <a href="#how">How it Works</a>
-              </li>
-              <li>
-                <a href="#enterprise">Enterprise</a>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <div className="text-sm font-semibold">Support</div>
-            <ul className="mt-3 space-y-2 text-sm text-white/70">
-              <li>
-                <a href="#docs">Docs</a>
-              </li>
-              <li>
-                <a href="#blog">Blog</a>
-              </li>
-              <li>
-                <a href="#contact">Contact</a>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <div className="text-sm font-semibold">Legal & Company</div>
-            <ul className="mt-3 space-y-2 text-sm text-white/70">
-              <li>
-                <a href="#privacy">Privacy Policy</a>
-              </li>
-              <li>
-                <a href="#terms">Terms of Service</a>
-              </li>
-              <li>
-                <a href="#careers">Careers</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div className="border-t border-white/10 py-6 text-center text-xs text-white/60">
-          © {new Date().getFullYear()} Visual AI Agents Builder. All rights reserved.
-        </div>
-      </footer>
+      {shouldRenderDeferred ? (
+        <Suspense fallback={<DeferredSkeleton />}>
+          <LazyDeferredSections />
+        </Suspense>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- split the landing page so the navigation and hero render immediately while the rest loads from a deferred bundle after the browser goes idle
- remove the framer-motion dependency from the landing view by replacing the animated arrow and menu transitions with lightweight CSS and state logic
- document the new fast-loading approach for the landing page so future updates keep the hero-first render behavior

## Testing
- npx prettier --check src/pages/LandingPage/index.tsx src/pages/LandingPage/DeferredSections.tsx src/pages/LandingPage/icons.tsx

------
https://chatgpt.com/codex/tasks/task_e_6900bf06cb108326b5929b6131b268ac