### PR TITLE
Scope frontend1 routing to public pages

### DIFF
--- a/src/frontend1/src/components/authorization/authLoginGuard/index.tsx
+++ b/src/frontend1/src/components/authorization/authLoginGuard/index.tsx
@@ -1,4 +1,3 @@
-import { CustomNavigate } from "@/customization/components/custom-navigate";
 import useAuthStore from "@/stores/authStore";
 import { useOrganization } from "@clerk/clerk-react";
 import { IS_CLERK_AUTH } from "@/clerk/auth";
@@ -45,11 +44,17 @@ export const ProtectedLoginRoute = ({ children }) => {
   if (canRedirect) {
     const urlParams = new URLSearchParams(window.location.search);
     const redirectPath = urlParams.get("redirect");
+    const fallbackRedirect =
+      import.meta.env.VITE_FULL_APP_BASE_PATH ?? "/flows";
 
-    if (redirectPath) {
-      return <CustomNavigate to={redirectPath} replace />;
+    const target = redirectPath || fallbackRedirect;
+
+    // Force a full navigation so nginx hands the request to frontend2.
+    if (typeof window !== "undefined") {
+      window.location.replace(target);
     }
-    return <CustomNavigate to="/flows" replace />;
+
+    return null;
   }
   return children;
 };

--- a/src/frontend1/src/routes.tsx
+++ b/src/frontend1/src/routes.tsx
@@ -1,423 +1,66 @@
 import { Suspense, lazy } from "react";
 import {
-  createBrowserRouter,
-  createRoutesFromElements,
   Outlet,
   Route,
+  createBrowserRouter,
+  createRoutesFromElements,
 } from "react-router-dom";
-import { ProtectedAdminRoute } from "./components/authorization/authAdminGuard";
-import { ProtectedRoute } from "./components/authorization/authGuard";
+
 import { ProtectedLoginRoute } from "./components/authorization/authLoginGuard";
-import { AuthSettingsGuard } from "./components/authorization/authSettingsGuard";
 import ContextWrapper from "./contexts";
 import { CustomNavigate } from "./customization/components/custom-navigate";
 import { BASENAME } from "./customization/config-constants";
-import {
-  ENABLE_CUSTOM_PARAM,
-  ENABLE_FILE_MANAGEMENT,
-  ENABLE_KNOWLEDGE_BASES,
-} from "./customization/feature-flags";
-import { CustomRoutesStore } from "./customization/utils/custom-routes-store";
-import { CustomRoutesStorePages } from "./customization/utils/custom-routes-store-pages";
 import { LoadingPage } from "./pages/LoadingPage";
-import { CollectionIndexRedirect } from "./routes/CollectionIndexRedirect";
-import { CatchAllRedirect } from "./routes/CatchAllRedirect";
-import { WorkspaceLoadingPage } from "./pages/WorkspaceLoadingPage";
 
-// ---- Lazy imports (your HEAD) ----
-const AppWrapperPage = lazy(() =>
-  import("./pages/AppWrapperPage").then((module) => ({
-    default: module.AppWrapperPage,
-  })),
-);
-const AppInitPage = lazy(() =>
-  import("./pages/AppInitPage").then((module) => ({
-    default: module.AppInitPage,
-  })),
-);
-const AppAuthenticatedPage = lazy(() =>
-  import("./pages/AppAuthenticatedPage").then((module) => ({
-    default: module.AppAuthenticatedPage,
-  })),
-);
-const CustomDashboardWrapperPage = lazy(
-  () => import("./customization/components/custom-DashboardWrapperPage"),
-);
-const CollectionPage = lazy(() => import("./pages/MainPage/pages/main-page"));
-const HomePage = lazy(() => import("./pages/MainPage/pages/homePage"));
-const FilesPage = lazy(() => import("./pages/MainPage/pages/filesPage"));
-const FlowPage = lazy(() => import("./pages/FlowPage"));
-const SettingsPage = lazy(() => import("./pages/SettingsPage"));
-const GlobalVariablesPage = lazy(
-  () => import("./pages/SettingsPage/pages/GlobalVariablesPage"),
-);
-const ApiKeysPage = lazy(() => import("./pages/SettingsPage/pages/ApiKeysPage"));
-const GeneralPage = lazy(
-  () => import("./pages/SettingsPage/pages/GeneralPage"),
-);
-const ShortcutsPage = lazy(
-  () => import("./pages/SettingsPage/pages/ShortcutsPage"),
-);
-const MessagesPage = lazy(
-  () => import("./pages/SettingsPage/pages/messagesPage"),
-);
-const MCPServersPage = lazy(
-  () => import("./pages/SettingsPage/pages/MCPServersPage"),
-);
-const KnowledgePage = lazy(
-  () => import("./pages/MainPage/pages/knowledgePage"),
-);
-const ViewPage = lazy(() => import("./pages/ViewPage"));
-const OrganizationPage = lazy(() => import("./clerk/OrganizationPage"));
+const LandingPage = lazy(() => import("./pages/LandingPage"));
 const LoginPage = lazy(() =>
   import("./clerk/login-pages").then((module) => ({
     default: module.LoginPage,
   })),
 );
-const SignUp = lazy(() =>
-  import("./clerk/login-pages").then((module) => ({
-    default: module.SignUp,
-  })),
-);
-const LoginAdminPage = lazy(() =>
-  import("./clerk/login-pages").then((module) => ({
-    default: module.LoginAdminPage,
-  })),
-);
+const OrganizationPage = lazy(() => import("./clerk/OrganizationPage"));
 
-const AdminPage = lazy(() => import("./pages/AdminPage"));
-const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
-const PlaygroundPage = lazy(() => import("./pages/Playground"));
-
-// ---- Router ----
 const router = createBrowserRouter(
-  createRoutesFromElements([
-    <Route path="/playground/:id/">
-      <Route
-        path=""
-        element={
-          <ContextWrapper key={1}>
-            <Suspense fallback={<LoadingPage />}>
-              <PlaygroundPage />
-            </Suspense>
-          </ContextWrapper>
-        }
-      />
-    </Route>,
+  createRoutesFromElements(
     <Route
-      path={ENABLE_CUSTOM_PARAM ? "/:customParam?" : "/"}
+      path="/"
       element={
-        <ContextWrapper key={2}>
+        <ContextWrapper>
           <Outlet />
         </ContextWrapper>
       }
     >
       <Route
-        path=""
+        index
         element={
           <Suspense fallback={<LoadingPage />}>
-            <AppWrapperPage />
+            <LandingPage />
           </Suspense>
         }
-      >
-        <Route
-          path=""
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedRoute>
-                <AppInitPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        >
-          <Route
-            path=""
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <AppAuthenticatedPage />
-              </Suspense>
-            }
-          >
-            <Route
-              path=""
-              element={
-                <Suspense fallback={<LoadingPage />}>
-                  <CustomDashboardWrapperPage />
-                </Suspense>
-              }
-            >
-              <Route
-                path=""
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <CollectionPage />
-                  </Suspense>
-                }
-              >
-                <Route index element={<CollectionIndexRedirect />} />
-                <Route
-                  index
-                  element={<CustomNavigate replace to={"flows"} />}
-                />
-                {ENABLE_FILE_MANAGEMENT && (
-                  <Route path="assets">
-                    <Route
-                      index
-                      element={<CustomNavigate replace to="files" />}
-                    />
-                    <Route
-                      path="files"
-                      element={
-                        <Suspense fallback={<LoadingPage />}>
-                          <FilesPage />
-                        </Suspense>
-                      }
-                    />
-                    {ENABLE_KNOWLEDGE_BASES && (
-                      <Route
-                        path="knowledge-bases"
-                        element={
-                          <Suspense fallback={<LoadingPage />}>
-                            <KnowledgePage />
-                          </Suspense>
-                        }
-                      />
-                    )}
-                  </Route>
-                )}
-                <Route
-                  path="flows/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="components/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="components" type="components" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="components" type="components" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="all/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="flows" type="flows" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="flows" type="flows" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-                <Route
-                  path="mcp/"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <HomePage key="mcp" type="mcp" />
-                    </Suspense>
-                  }
-                >
-                  <Route
-                    path="folder/:folderId"
-                    element={
-                      <Suspense fallback={<LoadingPage />}>
-                        <HomePage key="mcp" type="mcp" />
-                      </Suspense>
-                    }
-                  />
-                </Route>
-              </Route>
-
-              {/* Settings Routes */}
-              <Route
-                path="settings"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <SettingsPage />
-                  </Suspense>
-                }
-              >
-                <Route index element={<CustomNavigate replace to="general" />} />
-                <Route
-                  path="global-variables"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <GlobalVariablesPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="mcp-servers"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <MCPServersPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="api-keys"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ApiKeysPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="general/:scrollId?"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <AuthSettingsGuard>
-                        <GeneralPage />
-                      </AuthSettingsGuard>
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="shortcuts"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <ShortcutsPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path="messages"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <MessagesPage />
-                    </Suspense>
-                  }
-                />
-                {CustomRoutesStore()}
-              </Route>
-
-              {CustomRoutesStorePages()}
-
-              <Route path="account">
-                <Route
-                  path="delete"
-                  element={
-                    <Suspense fallback={<LoadingPage />}>
-                      <DeleteAccountPage />
-                    </Suspense>
-                  }
-                />
-              </Route>
-
-              <Route
-                path="admin"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ProtectedAdminRoute>
-                      <AdminPage />
-                    </ProtectedAdminRoute>
-                  </Suspense>
-                }
-              />
-            </Route>
-
-            {/* Flow and View Routes */}
-            <Route path="flow/:id/">
-              <Route
-                path=""
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <CustomDashboardWrapperPage />
-                  </Suspense>
-                }
-              >
-                <Route
-                  path="folder/:folderId/"
-                  element={
-                    <Suspense fallback={<WorkspaceLoadingPage />}>
-                      <FlowPage />
-                    </Suspense>
-                  }
-                />
-                <Route
-                  path=""
-                  element={
-                    <Suspense fallback={<WorkspaceLoadingPage />}>
-                      <FlowPage />
-                    </Suspense>
-                  }
-                />
-              </Route>
-              <Route
-                path="view"
-                element={
-                  <Suspense fallback={<LoadingPage />}>
-                    <ViewPage />
-                  </Suspense>
-                }
-              />
-            </Route>
-          </Route>
-        </Route>
-
-        {/* Auth routes */}
-        <Route
-          path="login"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="organization"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <OrganizationPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="signup"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <SignUp />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="login/admin"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <ProtectedLoginRoute>
-                <LoginAdminPage />
-              </ProtectedLoginRoute>
-            </Suspense>
-          }
-        />
-      </Route>
-      <Route path="*" element={<CatchAllRedirect />} />
+      />
+      <Route
+        path="login"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <LoginPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route
+        path="organization"
+        element={
+          <Suspense fallback={<LoadingPage />}>
+            <ProtectedLoginRoute>
+              <OrganizationPage />
+            </ProtectedLoginRoute>
+          </Suspense>
+        }
+      />
+      <Route path="*" element={<CustomNavigate replace to="/" />} />
     </Route>,
-  ]),
+  ),
   { basename: BASENAME || undefined },
 );
 


### PR DESCRIPTION
## Summary
- trim the frontend1 router down to the landing, login, and organization routes
- update the login guard to force a full navigation to the main app when an authenticated user hits the marketing app

## Testing
- pnpm --filter frontend1 build *(fails: No projects matched the filters in /workspace/DragDropAIAgentBuilder)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b4d828788326acaa093287d8b349)