### PR TITLE
Install supervisord and ship static config for Langflow startup

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -86,7 +86,7 @@ ARG FRONTEND2_DIR=frontend2-static
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y curl git libpq5 gnupg nginx \
+    && apt-get install -y curl git libpq5 gnupg nginx supervisor \
     && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean \
@@ -100,6 +100,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 COPY ${FRONTEND2_DIR}/ /usr/share/nginx/frontend2/
 COPY deploy/nginx-extra.conf /etc/nginx/conf.d/frontend2.conf.template
+COPY scripts/langflow_supervisord.conf /app/scripts/langflow_supervisord.conf
 COPY scripts/start_with_nginx.sh /app/scripts/start_with_nginx.sh
 
 RUN chmod +x /app/scripts/start_with_nginx.sh \

--- a/scripts/langflow_supervisord.conf
+++ b/scripts/langflow_supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+
+[program:langflow]
+command=langflow run --host %(ENV_LANGFLOW_HOST)s --port %(ENV_LANGFLOW_BACKEND_PORT)s --log-level info
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/tmp/langflow.log
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/tmp/nginx.log

--- a/scripts/start_with_nginx.sh
+++ b/scripts/start_with_nginx.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+
 BACKEND_HOST="${LANGFLOW_HOST:-0.0.0.0}"
 PUBLIC_PORT="${LANGFLOW_PORT:-7860}"
 BACKEND_PORT="${LANGFLOW_BACKEND_PORT:-7861}"
@@ -20,39 +22,16 @@ if [ -f "$CONFIG_TEMPLATE" ]; then
     "$CONFIG_TEMPLATE" > "$CONFIG_PATH"
 fi
 
-cleanup() {
-  if [ -n "${BACKEND_PID:-}" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
-    kill "$BACKEND_PID"
-  fi
-  if [ -n "${NGINX_PID:-}" ] && kill -0 "$NGINX_PID" 2>/dev/null; then
-    kill "$NGINX_PID"
-  fi
-}
+SUPERVISORD_CONF="${SCRIPT_DIR}/langflow_supervisord.conf"
 
-trap 'cleanup' INT TERM
+if [ ! -f "$SUPERVISORD_CONF" ]; then
+  echo "Supervisor configuration not found at $SUPERVISORD_CONF" >&2
+  exit 1
+fi
 
-langflow run --host "$BACKEND_HOST" --port "$BACKEND_PORT" --log-level info &
-BACKEND_PID=$!
+if ! command -v supervisord >/dev/null 2>&1; then
+  echo "supervisord is not installed or not available in PATH" >&2
+  exit 1
+fi
 
-/usr/sbin/nginx -g "daemon off;" &
-NGINX_PID=$!
-
-while :; do
-  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
-    wait "$BACKEND_PID"
-    EXIT_CODE=$?
-    cleanup
-    wait "$NGINX_PID" 2>/dev/null || true
-    exit "$EXIT_CODE"
-  fi
-
-  if ! kill -0 "$NGINX_PID" 2>/dev/null; then
-    wait "$NGINX_PID"
-    EXIT_CODE=$?
-    cleanup
-    wait "$BACKEND_PID" 2>/dev/null || true
-    exit "$EXIT_CODE"
-  fi
-
-  sleep 1
-done
+exec supervisord -c "$SUPERVISORD_CONF"


### PR DESCRIPTION
## Summary
- add a dedicated supervisord configuration checked into scripts/
- update the startup script to use the static config and validate supervisord availability
- install supervisord in the Docker image so the entrypoint can invoke it

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691843d4f9c8832690456428a79ff195)