### PR TITLE
Ensure Clerk publishable key is injected into static frontend

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -83,6 +83,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM python:3.12.3-slim AS runtime
 
 ARG FRONTEND2_DIR=frontend2-static
+ARG VITE_CLERK_PUBLISHABLE_KEY=""
+ARG VITE_CLERK_FRONTEND_API=""
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -93,12 +95,18 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
+ENV VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_CLERK_FRONTEND_API=$VITE_CLERK_FRONTEND_API
+
 COPY --from=builder --chown=1000 /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY ${FRONTEND2_DIR}/ /usr/share/nginx/frontend2/
+COPY scripts/configure_frontend2_static.py /tmp/configure_frontend2_static.py
+RUN python /tmp/configure_frontend2_static.py --source /usr/share/nginx/frontend2 \
+    && rm /tmp/configure_frontend2_static.py
 COPY deploy/nginx-extra.conf /etc/nginx/conf.d/frontend2.conf.template
 COPY scripts/langflow_supervisord.conf /app/scripts/langflow_supervisord.conf
 COPY scripts/start_with_nginx.sh /app/scripts/start_with_nginx.sh

--- a/frontend2-static/dashboard.html
+++ b/frontend2-static/dashboard.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="clerk-publishable-key" content="" />
     <title>Langflow dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/scripts/configure_frontend2_static.py
+++ b/scripts/configure_frontend2_static.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Inject environment configuration into frontend2 static assets.
+
+Updates Clerk publishable key meta tags when a key is available so that the
+standalone static experience can bootstrap Clerk without additional scripts.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+META_PATTERN = re.compile(
+    r'(\<meta\s+name="clerk-publishable-key"\s+content=")(.*?)("\s*/?>)',
+    flags=re.IGNORECASE,
+)
+
+
+def update_meta_tag(path: Path, publishable_key: str) -> bool:
+    """Update the Clerk publishable key meta tag for a single HTML file."""
+    original = path.read_text(encoding="utf-8")
+    match = META_PATTERN.search(original)
+    if not match:
+        return False
+
+    if match.group(2) == publishable_key:
+        return True
+
+    updated = META_PATTERN.sub(
+        lambda m: f"{m.group(1)}{publishable_key}{m.group(3)}", original, count=1
+    )
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def configure_frontend(source: Path, publishable_key: str) -> list[Path]:
+    """Inject the publishable key into all HTML files under ``source``."""
+    updated_files: list[Path] = []
+    for path in source.rglob("*.html"):
+        if update_meta_tag(path, publishable_key):
+            updated_files.append(path)
+    return updated_files
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inject Clerk configuration into the frontend2 static bundle",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "frontend2-static",
+        help="Path to the frontend2 static directory (defaults to repository copy)",
+    )
+    parser.add_argument(
+        "--publishable-key",
+        dest="publishable_key",
+        default=None,
+        help="Explicit Clerk publishable key (defaults to environment)",
+    )
+    args = parser.parse_args(argv)
+
+    publishable_key = (
+        args.publishable_key
+        or os.getenv("VITE_CLERK_PUBLISHABLE_KEY")
+        or os.getenv("CLERK_PUBLISHABLE_KEY")
+    )
+
+    if not publishable_key:
+        print(
+            "[configure_frontend2_static] No Clerk publishable key provided; "
+            "skipping injection.",
+            file=sys.stderr,
+        )
+        return 0
+
+    source = args.source
+    if not source.exists():
+        parser.error(f"Source directory '{source}' does not exist")
+
+    updated = configure_frontend(source, publishable_key)
+    if not updated:
+        print(
+            "[configure_frontend2_static] No Clerk meta tags found to update.",
+            file=sys.stderr,
+        )
+        return 0
+
+    for path in updated:
+        print(f"[configure_frontend2_static] Updated {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a utility script that injects the configured Clerk publishable key into frontend2 static HTML files
- propagate the Clerk build arguments to the runtime image and run the injector during the Docker build
- expose the publishable key meta tag on the dashboard page so Clerk can load there as well

## Testing
- TMP_DIR=$(mktemp -d) && cp -r frontend2-static/. "$TMP_DIR"/ && VITE_CLERK_PUBLISHABLE_KEY=pk_test_example python scripts/configure_frontend2_static.py --source "$TMP_DIR"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918659b156883269a2301fb5ce8434c)