### PR TITLE
Enable websocket support and centralize Clerk static config

### DIFF
--- a/deploy/nginx-extra.conf
+++ b/deploy/nginx-extra.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     listen {{NGINX_PORT}};
     server_name _;
@@ -18,6 +23,8 @@ server {
     location / {
         proxy_pass http://127.0.0.1:{{BACKEND_PORT}};
         proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/frontend/default.conf.template
+++ b/docker/frontend/default.conf.template
@@ -7,6 +7,11 @@ http {
     default_type text/plain;
     client_max_body_size ${LANGFLOW_MAX_FILE_SIZE_UPLOAD}M;
 
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
     types {
         text/html html;
         text/css css;
@@ -39,12 +44,33 @@ http {
 
         location /api {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
         location /health_check {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
         location /health {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         include /etc/nginx/extra-conf.d/*.conf;

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     gzip on;
     gzip_comp_level  2;
@@ -18,12 +23,33 @@ server {
     }
     location /api {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /health_check {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /health {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     include /etc/nginx/extra-conf.d/*.conf;

--- a/frontend2-static/scripts/clerk-config.js
+++ b/frontend2-static/scripts/clerk-config.js
@@ -1,0 +1,141 @@
+const EXPLICIT_CLERK_CONFIG = Object.freeze({
+  /**
+   * Replace the empty string below with your Clerk publishable key during the build.
+   * Example: "pk_test_123456789".
+   */
+  publishableKey: "",
+  /**
+   * Replace the empty string below with your Clerk frontend API (without protocol).
+   * Example: "clerk.yourapp.dev".
+   */
+  frontendApi: "",
+});
+
+const STORAGE_KEY = "lf-clerk-publishable-key";
+const FRONTEND_API_STORAGE_KEY = "lf-clerk-frontend-api";
+
+function safeTrim(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readFromLocalStorage(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`[clerk-config] Unable to access localStorage for ${key}`, error);
+    return "";
+  }
+}
+
+function writeToLocalStorage(key, value) {
+  try {
+    if (value) {
+      localStorage.setItem(key, value);
+    }
+  } catch (error) {
+    console.warn(`[clerk-config] Unable to persist ${key} in localStorage`, error);
+  }
+}
+
+function coalesce(...values) {
+  for (const value of values) {
+    const trimmed = safeTrim(value);
+    if (trimmed) return trimmed;
+  }
+  return "";
+}
+
+export function getExplicitClerkConfig() {
+  return EXPLICIT_CLERK_CONFIG;
+}
+
+export function getClerkPublishableKey() {
+  const explicit = safeTrim(EXPLICIT_CLERK_CONFIG.publishableKey);
+  if (explicit) return explicit;
+
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const candidates = [
+    window.CLERK_PUBLISHABLE_KEY,
+    window.VITE_CLERK_PUBLISHABLE_KEY,
+    window.__CLERK_PUBLISHABLE_KEY__,
+    window?.__env__?.VITE_CLERK_PUBLISHABLE_KEY,
+    window?.__ENV__?.VITE_CLERK_PUBLISHABLE_KEY,
+  ];
+
+  if (typeof document !== "undefined") {
+    candidates.push(
+      document.querySelector('meta[name="clerk-publishable-key"]')?.content,
+    );
+  }
+
+  candidates.push(readFromLocalStorage(STORAGE_KEY));
+
+  return coalesce(...candidates);
+}
+
+export function getClerkFrontendApi() {
+  const explicit = safeTrim(EXPLICIT_CLERK_CONFIG.frontendApi);
+  if (explicit) return explicit;
+
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const candidates = [
+    window.CLERK_FRONTEND_API,
+    window.__CLERK_FRONTEND_API__,
+    window?.__env__?.VITE_CLERK_FRONTEND_API,
+    window?.__ENV__?.VITE_CLERK_FRONTEND_API,
+    readFromLocalStorage(FRONTEND_API_STORAGE_KEY),
+  ];
+
+  return coalesce(...candidates);
+}
+
+export function applyClerkConfigToWindow() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const publishableKey = getClerkPublishableKey();
+  const frontendApi = getClerkFrontendApi();
+
+  if (publishableKey) {
+    window.CLERK_PUBLISHABLE_KEY = publishableKey;
+    window.VITE_CLERK_PUBLISHABLE_KEY = publishableKey;
+    window.__CLERK_PUBLISHABLE_KEY__ = publishableKey;
+  }
+
+  if (frontendApi) {
+    window.CLERK_FRONTEND_API = frontendApi;
+    window.__CLERK_FRONTEND_API__ = frontendApi;
+  }
+
+  if (typeof document !== "undefined") {
+    const metaName = "clerk-publishable-key";
+    let meta = document.querySelector(`meta[name="${metaName}"]`);
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = metaName;
+      document.head.appendChild(meta);
+    }
+    if (publishableKey) {
+      meta.content = publishableKey;
+    }
+  }
+
+  if (publishableKey) {
+    writeToLocalStorage(STORAGE_KEY, publishableKey);
+  }
+  if (frontendApi) {
+    writeToLocalStorage(FRONTEND_API_STORAGE_KEY, frontendApi);
+  }
+}
+
+applyClerkConfigToWindow();
+
+export const CLERK_PUBLISHABLE_KEY = getClerkPublishableKey();
+export const CLERK_FRONTEND_API = getClerkFrontendApi();

--- a/frontend2-static/scripts/clerk-loader.js
+++ b/frontend2-static/scripts/clerk-loader.js
@@ -1,33 +1,43 @@
+import {
+  CLERK_FRONTEND_API,
+  CLERK_PUBLISHABLE_KEY,
+  applyClerkConfigToWindow,
+  getClerkFrontendApi,
+  getClerkPublishableKey,
+} from "./clerk-config.js";
+
 const CLERK_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@clerk/clerk-js@latest";
-const STORAGE_KEY = "lf-clerk-publishable-key";
 
-function resolvePublishableKey() {
-  const candidates = [
-    () => document.querySelector('meta[name="clerk-publishable-key"]')?.content,
-    () => window.CLERK_PUBLISHABLE_KEY,
-    () => window.VITE_CLERK_PUBLISHABLE_KEY,
-    () => window.__CLERK_PUBLISHABLE_KEY__,
-    () => window?.__env__?.VITE_CLERK_PUBLISHABLE_KEY,
-    () => window?.__ENV__?.VITE_CLERK_PUBLISHABLE_KEY,
-    () => localStorage.getItem(STORAGE_KEY),
-  ];
-
-  for (const getter of candidates) {
-    try {
-      const value = getter();
-      if (typeof value === "string" && value.trim().length > 0) {
-        localStorage.setItem(STORAGE_KEY, value.trim());
-        return value.trim();
-      }
-    } catch (error) {
-      console.warn("[clerk-loader] Unable to read candidate key", error);
+function rememberResolvedConfig(publishableKey, frontendApi) {
+  if (typeof window === "undefined") return;
+  try {
+    if (publishableKey && publishableKey !== CLERK_PUBLISHABLE_KEY) {
+      window.localStorage.setItem("lf-clerk-publishable-key", publishableKey);
     }
+    if (frontendApi && frontendApi !== CLERK_FRONTEND_API) {
+      window.localStorage.setItem("lf-clerk-frontend-api", frontendApi);
+    }
+  } catch (error) {
+    console.warn("[clerk-loader] Unable to persist Clerk settings", error);
   }
-
-  throw new Error("Missing Clerk publishable key. Ensure it is exposed to window or meta tag.");
 }
 
-function injectScript(publishableKey) {
+function resolvePublishableKey() {
+  const publishableKey = getClerkPublishableKey();
+  if (publishableKey) {
+    return publishableKey;
+  }
+
+  throw new Error(
+    "Missing Clerk publishable key. Ensure it is configured in scripts/clerk-config.js or exposed globally.",
+  );
+}
+
+function resolveFrontendApi() {
+  return getClerkFrontendApi();
+}
+
+function injectScript(publishableKey, frontendApi) {
   return new Promise((resolve, reject) => {
     if (window.Clerk) {
       resolve();
@@ -43,6 +53,9 @@ function injectScript(publishableKey) {
     script.src = CLERK_SCRIPT_URL;
     script.async = true;
     script.setAttribute("data-clerk-publishable-key", publishableKey);
+    if (frontendApi) {
+      script.setAttribute("data-clerk-frontend-api", frontendApi);
+    }
     script.addEventListener("load", () => resolve());
     script.addEventListener("error", () => reject(new Error("Failed to load Clerk script")));
     document.head.appendChild(script);
@@ -52,14 +65,21 @@ function injectScript(publishableKey) {
 let clerkPromise = null;
 
 export async function loadClerk() {
+  applyClerkConfigToWindow();
+
   if (clerkPromise) return clerkPromise;
   clerkPromise = (async () => {
     const publishableKey = resolvePublishableKey();
-    await injectScript(publishableKey);
+    const frontendApi = resolveFrontendApi();
+    await injectScript(publishableKey, frontendApi);
     if (!window.Clerk) {
       throw new Error("Clerk failed to initialise");
     }
-    return window.Clerk.load({ publishableKey });
+    rememberResolvedConfig(publishableKey, frontendApi);
+    const loadOptions = frontendApi
+      ? { publishableKey, frontendApi }
+      : { publishableKey };
+    return window.Clerk.load(loadOptions);
   })();
   return clerkPromise;
 }


### PR DESCRIPTION
## Summary
- add websocket upgrade handling to the nginx configurations used in Docker so websocket traffic reaches the React frontend
- add a reusable Clerk configuration module for the static frontend so publishable key and frontend API are defined once and shared across scripts

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691882b5ffd48326bbf3f7830881662a)