### PR TITLE
Restore user optins defaults

### DIFF
--- a/src/backend/base/langflow/services/database/constants.py
+++ b/src/backend/base/langflow/services/database/constants.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+DUMMY_USER_NAMESPACE_TEMPLATE = "langflow.org/{org_id}/dummy-user"
+
+__all__ = ["DUMMY_USER_NAMESPACE_TEMPLATE"]


### PR DESCRIPTION
## Summary
- revert user creation opt-in defaults to their previous single-line form per review feedback

## Testing
- python -m compileall src/backend/base/langflow/services/database

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692beda2e7a08326a698a1624fb0f84e)