### PR TITLE
Apply dummy user opt-ins to Clerk signups

### DIFF
--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -31,7 +31,7 @@ async def add_user(
     """Add a new user to the database."""
     new_user = User.model_validate(user, from_attributes=True)
     try:
-        await process_new_user_with_clerk(new_user)
+        await process_new_user_with_clerk(new_user, session)
         new_user.password = get_password_hash(user.password)
         new_user.is_active = get_settings_service().auth_settings.NEW_USER_IS_ACTIVE
         session.add(new_user)


### PR DESCRIPTION
## Summary
- derive the organization from the Clerk payload and fetch dummy user opt-in values
- populate new Clerk users with skip_trial_access and trial_access_until based on dummy settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c233aa2888326b3367d73cdea780e)