### PR TITLE
Add admin settings page for superusers

### DIFF
--- a/src/frontend/src/customization/components/ClerkAccountMenu.tsx
+++ b/src/frontend/src/customization/components/ClerkAccountMenu.tsx
@@ -1,6 +1,6 @@
 import { UserButton, useClerk, useUser } from "@clerk/clerk-react";
 import { IS_CLERK_AUTH, useLogout } from "@/clerk/auth";
-import { LogOut, Users, Settings, User } from "lucide-react";
+import { LogOut, Users, Settings, User, ShieldCheck } from "lucide-react";
 import { AccountMenu } from "@/components/core/appHeaderComponent/components/AccountMenu";
 import { cn } from "@/utils/utils";
 import {
@@ -11,12 +11,14 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useState } from "react";
 import ThemeButtons from "@/components/core/appHeaderComponent/components/ThemeButtons";
+import useAuthStore from "@/stores/authStore";
 
 export function ClerkAccountMenu() {
   const { mutate: mutationLogout } = useLogout();
   const { openUserProfile, openOrganizationProfile } = useClerk();
   const { user } = useUser();
   const [menuOpen, setMenuOpen] = useState(false);
+  const isAdmin = useAuthStore((state) => state.isAdmin);
 
   const handleLogout = () => {
     mutationLogout();
@@ -89,6 +91,19 @@ export function ClerkAccountMenu() {
             <Users className="h-4 w-4" />
             Members
           </DropdownMenuItem>
+
+          {/* Admin Settings */}
+          {isAdmin && (
+            <DropdownMenuItem asChild>
+              <a
+                href="/new/landingpage/admin_settings"
+                className="flex items-center gap-3 px-5 py-3 rounded-lg hover:bg-muted/30 transition"
+              >
+                <ShieldCheck className="h-4 w-4" />
+                Admin Settings
+              </a>
+            </DropdownMenuItem>
+          )}
 
           {/* Settings */}
           <DropdownMenuItem asChild>

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -14,6 +14,7 @@ import ForwardedIconComponent from "../../components/common/genericIconComponent
 import PageLayout from "../../components/common/pageLayout";
 import { useClerk, useOrganization } from "@clerk/clerk-react";
 import { IS_CLERK_AUTH } from "@/clerk/auth";
+import useAuthStore from "@/stores/authStore";
 
 type SettingsPageBaseProps = {
   headerActions?: ReactNode;
@@ -107,6 +108,7 @@ const SettingsPageBase = ({
 const SettingsPageWithClerk = () => {
   const { openUserProfile, openOrganizationProfile } = useClerk();
   const { organization, isLoaded: isOrganizationLoaded } = useOrganization();
+  const isAdmin = useAuthStore((state) => state.isAdmin);
 
   const canManageMembers = Boolean(
     isOrganizationLoaded && organization?.id && openOrganizationProfile,
@@ -145,6 +147,19 @@ const SettingsPageWithClerk = () => {
       disabled: !canManageMembers,
     },
   ];
+
+  if (isAdmin) {
+    clerkNavItems.push({
+      title: "Admin Settings",
+      icon: (
+        <ForwardedIconComponent
+          name="Shield"
+          className="w-4 flex-shrink-0 justify-start stroke-[1.5]"
+        />
+      ),
+      href: "/new/landingpage/admin_settings",
+    });
+  }
 
   // Pass Clerk items so they show at the bottom
   return <SettingsPageBase additionalNavItems={clerkNavItems} />;

--- a/src/new-landingpage/src/AdminSettingsPage.tsx
+++ b/src/new-landingpage/src/AdminSettingsPage.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import { Navigate, useNavigate } from "react-router-dom";
+import { useAuth } from "@clerk/clerk-react";
+import { useCookies } from "react-cookie";
+import {
+  hasWorkspaceSession,
+  LANGFLOW_ACCESS_TOKEN,
+  LANGFLOW_REFRESH_TOKEN,
+} from "./session";
+
+const API_BASE = (import.meta.env.VITE_LANGFLOW_API_BASE ?? "/api/v1/")
+  .replace(/\/?$/, "/");
+
+async function requestJson(path: string, token: string) {
+  const response = await fetch(`${API_BASE}${path.replace(/^\/+/, "")}`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const text = await response.text();
+  const data = text ? (JSON.parse(text) as Record<string, any>) : null;
+
+  if (!response.ok) {
+    const detail = (data?.detail as string) ?? response.statusText;
+    throw new Error(detail || "Request failed");
+  }
+
+  return data;
+}
+
+type UserRecord = {
+  id?: string;
+  username?: string;
+  full_name?: string;
+  email?: string;
+  is_superuser?: boolean;
+  [key: string]: unknown;
+};
+
+export default function AdminSettingsPage() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const navigate = useNavigate();
+  const [cookies] = useCookies([LANGFLOW_ACCESS_TOKEN, LANGFLOW_REFRESH_TOKEN]);
+
+  const [userRecord, setUserRecord] = useState<UserRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    if (!isSignedIn) {
+      navigate("/login", { replace: true });
+      return;
+    }
+
+    if (!hasWorkspaceSession(cookies)) {
+      navigate("/organization", { replace: true });
+      return;
+    }
+
+    const token = cookies[LANGFLOW_ACCESS_TOKEN];
+    if (!token) {
+      setError("Missing access token.");
+      setLoading(false);
+      return;
+    }
+
+    requestJson("users/whoami", token)
+      .then((data) => {
+        setUserRecord(data);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, [cookies, isLoaded, isSignedIn, navigate]);
+
+  const isSuperuser = useMemo(() => userRecord?.is_superuser === true, [userRecord]);
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  if (!loading && userRecord && !isSuperuser) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#0b1021",
+        color: "#e2e8f0",
+        padding: "2rem",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          width: "min(900px, 100%)",
+          background: "#0f172a",
+          borderRadius: "1rem",
+          border: "1px solid rgba(255,255,255,0.04)",
+          boxShadow: "0 24px 80px rgba(0,0,0,0.35)",
+          padding: "2rem",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: "1.5rem",
+          }}
+        >
+          <div>
+            <p style={{ margin: 0, color: "#94a3b8", fontSize: "0.9rem" }}>Admin</p>
+            <h1 style={{ margin: 0, fontSize: "1.75rem", color: "#e2e8f0" }}>
+              Admin Settings
+            </h1>
+            <p style={{ marginTop: "0.25rem", color: "#cbd5e1" }}>
+              Review your user record as stored in Langflow.
+            </p>
+          </div>
+          <div
+            style={{
+              padding: "0.35rem 0.75rem",
+              borderRadius: "999px",
+              background: isSuperuser ? "rgba(16, 185, 129, 0.15)" : "rgba(248, 113, 113, 0.1)",
+              color: isSuperuser ? "#22c55e" : "#f87171",
+              fontWeight: 600,
+            }}
+          >
+            {isSuperuser ? "Superuser" : "Standard User"}
+          </div>
+        </div>
+
+        {loading && (
+          <div style={{ color: "#cbd5e1" }}>Loading user details…</div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              background: "rgba(248, 113, 113, 0.08)",
+              border: "1px solid rgba(248, 113, 113, 0.3)",
+              color: "#fecdd3",
+              padding: "1rem",
+              borderRadius: "0.75rem",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && userRecord && (
+          <div
+            style={{
+              marginTop: "1rem",
+              display: "grid",
+              gap: "0.75rem",
+            }}
+          >
+            {Object.entries(userRecord).map(([key, value]) => (
+              <div
+                key={key}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  background: "rgba(255,255,255,0.02)",
+                  border: "1px solid rgba(148, 163, 184, 0.15)",
+                  borderRadius: "0.75rem",
+                  padding: "0.85rem 1rem",
+                }}
+              >
+                <div style={{ color: "#94a3b8", textTransform: "capitalize" }}>{key}</div>
+                <div style={{ color: "#e2e8f0", fontWeight: 600 }}>
+                  {typeof value === "boolean"
+                    ? value.toString()
+                    : value === null || value === undefined
+                      ? "—"
+                      : String(value)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/new-landingpage/src/App.tsx
+++ b/src/new-landingpage/src/App.tsx
@@ -11,6 +11,7 @@ import {
   LANGFLOW_ACCESS_TOKEN,
   LANGFLOW_REFRESH_TOKEN,
 } from "./session";
+import AdminSettingsPage from "./AdminSettingsPage";
 
 const features = [
   "Visual builder for complex AI flows",
@@ -84,6 +85,7 @@ export default function App() {
         <Route path="/login" element={<NewLandingPageLogin />} />
         <Route path="/organization" element={<OrganizationOnboarding />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/admin_settings" element={<AdminSettingsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add an admin settings page under /new/landingpage/admin_settings that shows the current user record and restricts access to superusers
- expose the admin settings link to superusers in the account menu and as the final tab in the settings sidebar

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c40682c688326b02e3200cb2c84f1)