### PR TITLE
Hide Langflow badge on shareable playground

### DIFF
--- a/src/frontend/src/modals/IOModal/playground-modal.tsx
+++ b/src/frontend/src/modals/IOModal/playground-modal.tsx
@@ -426,7 +426,7 @@ export default function IOModal({
                     <Button
                       onClick={LangflowButtonClick}
                       variant="primary"
-                      className="hidden w-full !rounded-xl shadow-lg"
+                      className="!hidden w-full !rounded-xl shadow-lg"
                     >
                       <LangflowLogoColor />
                       <div className="text-sm">Built with Langflow</div>
@@ -444,7 +444,7 @@ export default function IOModal({
                 >
                   <Button
                     variant="primary"
-                    className="hidden h-12 w-12 !rounded-xl !p-4 shadow-lg"
+                    className="!hidden h-12 w-12 !rounded-xl !p-4 shadow-lg"
                     onClick={LangflowButtonClick}
                   >
                     <LangflowLogoColor className="h-[18px] w-[18px] scale-150" />


### PR DESCRIPTION
## Summary
- enforce hiding the “Built with Langflow” badge in the shareable playground view
- ensure both sidebar and collapsed playground badge buttons are fully hidden

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e1a2c7948326ac2d009a014b8565)