### PR TITLE
Add Stripe access control, webhook syncing and has_access gating

### DIFF
--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -18,6 +18,7 @@ from langflow.api.v1 import (
     organisation_router,
     projects_router,
     starter_projects_router,
+    stripe_webhook_router,
     store_router,
     users_router,
     validate_router,
@@ -51,6 +52,7 @@ router_v1.include_router(folders_router)
 router_v1.include_router(projects_router)
 router_v1.include_router(organisation_router)
 router_v1.include_router(starter_projects_router)
+router_v1.include_router(stripe_webhook_router)
 router_v1.include_router(knowledge_bases_router)
 router_v1.include_router(mcp_router)
 router_v1.include_router(voice_mode_router)

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -14,6 +14,7 @@ from langflow.api.v1.openai_responses import router as openai_responses_router
 from langflow.api.v1.organisation_router import router as organisation_router
 from langflow.api.v1.projects import router as projects_router
 from langflow.api.v1.starter_projects import router as starter_projects_router
+from langflow.api.v1.stripe_webhook import router as stripe_webhook_router
 from langflow.api.v1.store import router as store_router
 from langflow.api.v1.users import router as users_router
 from langflow.api.v1.validate import router as validate_router
@@ -37,6 +38,7 @@ __all__ = [
     "organisation_router",
     "projects_router",
     "starter_projects_router",
+    "stripe_webhook_router",
     "store_router",
     "users_router",
     "validate_router",

--- a/src/backend/base/langflow/api/v1/billing.py
+++ b/src/backend/base/langflow/api/v1/billing.py
@@ -71,6 +71,8 @@ async def create_stripe_checkout_session(
         "success_url": str(payload.success_url),
         "cancel_url": str(payload.cancel_url),
         "client_reference_id": str(current_user.id),
+        "subscription_data[metadata][user_id]": str(current_user.id),
+        "subscription_data[trial_period_days]": "7",
         "line_items[0][price_data][currency]": "usd",
         "line_items[0][price_data][unit_amount]": str(plan["amount"]),
         "line_items[0][price_data][product_data][name]": f"{plan['name']} Plan",

--- a/src/backend/base/langflow/api/v1/stripe_webhook.py
+++ b/src/backend/base/langflow/api/v1/stripe_webhook.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+
+from langflow.api.utils import DbSession
+from langflow.services.billing.access_control import update_user_from_stripe_payload
+
+router = APIRouter(prefix="/billing/stripe", tags=["Billing"])
+
+STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300
+
+
+def _parse_stripe_signature(signature_header: str) -> tuple[str | None, list[str]]:
+    timestamp = None
+    signatures: list[str] = []
+    for part in signature_header.split(","):
+        key, _, value = part.partition("=")
+        if key == "t":
+            timestamp = value
+        elif key == "v1":
+            signatures.append(value)
+    return timestamp, signatures
+
+
+def _verify_stripe_signature(payload: bytes, signature_header: str, secret: str) -> None:
+    timestamp, signatures = _parse_stripe_signature(signature_header)
+    if not timestamp or not signatures:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Stripe signature header")
+
+    try:
+        timestamp_int = int(timestamp)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Stripe signature timestamp") from exc
+
+    if abs(time.time() - timestamp_int) > STRIPE_SIGNATURE_TOLERANCE_SECONDS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Stripe signature timestamp out of tolerance")
+
+    signed_payload = f"{timestamp}.{payload.decode('utf-8')}".encode("utf-8")
+    expected_signature = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+
+    if not any(hmac.compare_digest(expected_signature, provided) for provided in signatures):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Stripe signature")
+
+
+def _get_webhook_secret() -> str:
+    secret = os.getenv("STRIPE_WEBHOOK_SECRET")
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Stripe webhook secret not configured",
+        )
+    return secret
+
+
+def _extract_user_id_from_subscription(subscription: dict[str, Any]) -> str | None:
+    metadata = subscription.get("metadata")
+    if isinstance(metadata, dict):
+        user_id = metadata.get("user_id")
+        if isinstance(user_id, str):
+            return user_id
+    return None
+
+
+async def _handle_checkout_completed(session: DbSession, payload: dict[str, Any]) -> None:
+    user_id = payload.get("client_reference_id")
+    updates = {
+        "stripe_customer_id": payload.get("customer"),
+        "stripe_subscription_id": payload.get("subscription"),
+        "stripe_subscription_status": "active",
+    }
+    await update_user_from_stripe_payload(session, user_id, updates)
+
+
+async def _handle_subscription_event(session: DbSession, payload: dict[str, Any]) -> None:
+    user_id = _extract_user_id_from_subscription(payload)
+    updates = {
+        "stripe_customer_id": payload.get("customer"),
+        "stripe_subscription_id": payload.get("id"),
+        "stripe_subscription_status": payload.get("status"),
+        "stripe_current_period_end": payload.get("current_period_end"),
+        "stripe_cancel_at_period_end": payload.get("cancel_at_period_end"),
+    }
+    await update_user_from_stripe_payload(session, user_id, updates)
+
+
+@router.post("/webhook")
+async def stripe_webhook(
+    request: Request,
+    session: DbSession,
+    stripe_signature: str | None = Header(default=None, alias="Stripe-Signature"),
+) -> dict[str, bool]:
+    if stripe_signature is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing Stripe signature header")
+
+    payload = await request.body()
+    _verify_stripe_signature(payload, stripe_signature, _get_webhook_secret())
+
+    event = json.loads(payload)
+    event_type = event.get("type")
+    event_data = event.get("data", {}).get("object", {})
+
+    if event_type == "checkout.session.completed":
+        await _handle_checkout_completed(session, event_data)
+    elif event_type in {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }:
+        await _handle_subscription_event(session, event_data)
+
+    return {"received": True}

--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -16,13 +16,24 @@ from langflow.services.auth.utils import (
     get_password_hash,
     verify_password,
 )
+from langflow.services.billing.access_control import ensure_user_has_access
 from langflow.services.database.models.user.crud import get_user_by_id, update_user
 from langflow.services.database.models.user.model import User, UserCreate, UserRead, UserUpdate
 from langflow.services.deps import get_settings_service
 
 router = APIRouter(tags=["Users"], prefix="/users")
 
-SENSITIVE_OPTIN_KEYS = {"skip_trial_access", "trial_access_until", "trial_access_days"}
+SENSITIVE_OPTIN_KEYS = {
+    "has_access",
+    "skip_trial_access",
+    "stripe_cancel_at_period_end",
+    "stripe_current_period_end",
+    "stripe_customer_id",
+    "stripe_subscription_id",
+    "stripe_subscription_status",
+    "trial_access_until",
+    "trial_access_days",
+}
 
 @router.post("/", response_model=UserRead, status_code=201)
 async def add_user(
@@ -51,9 +62,10 @@ async def add_user(
 @router.get("/whoami", response_model=UserRead)
 async def read_current_user(
     current_user: CurrentActiveUser,
+    session: DbSession,
 ) -> User:
     """Retrieve the current user's data."""
-    return current_user
+    return await ensure_user_has_access(session, current_user)
 
 
 @router.get("/", dependencies=[Depends(get_current_active_superuser)])

--- a/src/backend/base/langflow/services/auth/clerk_utils.py
+++ b/src/backend/base/langflow/services/auth/clerk_utils.py
@@ -12,6 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.status import HTTP_401_UNAUTHORIZED
 
 from langflow.logging.logger import logger
+from langflow.services.billing.access_control import set_has_access_optin
 from langflow.services.database.constants import DUMMY_USER_NAMESPACE_TEMPLATE
 from langflow.services.database.models.user import User
 from langflow.services.database.models.user.crud import get_user_by_id
@@ -141,11 +142,13 @@ async def _apply_dummy_user_optins(
     trial_access_days = dummy_optins.get("trial_access_days", 7)
     trial_access_until = (datetime.now(timezone.utc) + timedelta(days=trial_access_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    new_user.optins = {
-        **(new_user.optins or {}),
-        "skip_trial_access": skip_trial_access,
-        "trial_access_until": trial_access_until,
-    }
+    new_user.optins = set_has_access_optin(
+        {
+            **(new_user.optins or {}),
+            "skip_trial_access": skip_trial_access,
+            "trial_access_until": trial_access_until,
+        }
+    )
 
 
 async def process_new_user_with_clerk(new_user: User, session: AsyncSession | None = None):

--- a/src/backend/base/langflow/services/billing/__init__.py
+++ b/src/backend/base/langflow/services/billing/__init__.py
@@ -1,0 +1,1 @@
+"""Billing service helpers."""

--- a/src/backend/base/langflow/services/billing/access_control.py
+++ b/src/backend/base/langflow/services/billing/access_control.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from langflow.services.database.models.user.crud import get_user_by_id
+from langflow.services.database.models.user.model import User
+
+
+ACCESS_ACTIVE_STATUSES = {"active", "trialing"}
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def compute_has_access(optins: dict[str, Any]) -> bool:
+    if optins.get("skip_trial_access"):
+        return True
+
+    subscription_status = optins.get("stripe_subscription_status")
+    if subscription_status in ACCESS_ACTIVE_STATUSES:
+        return True
+
+    trial_until = _parse_iso_datetime(optins.get("trial_access_until"))
+    if trial_until and trial_until > datetime.now(timezone.utc):
+        return True
+
+    return False
+
+
+def set_has_access_optin(optins: dict[str, Any]) -> dict[str, Any]:
+    updated = {**optins}
+    updated["has_access"] = compute_has_access(updated)
+    return updated
+
+
+async def update_user_optins(
+    session: AsyncSession,
+    user: User,
+    updates: dict[str, Any],
+) -> User:
+    optins = {**(user.optins or {})}
+    optins.update(updates)
+    optins = set_has_access_optin(optins)
+    user.optins = optins
+    flag_modified(user, "optins")
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def ensure_user_has_access(session: AsyncSession, user: User) -> User:
+    optins = {**(user.optins or {})}
+    updated = set_has_access_optin(optins)
+    if updated != optins:
+        user.optins = updated
+        flag_modified(user, "optins")
+        await session.commit()
+        await session.refresh(user)
+    return user
+
+
+async def update_user_from_stripe_payload(
+    session: AsyncSession,
+    user_id: str | None,
+    updates: dict[str, Any],
+) -> User | None:
+    if not user_id:
+        return None
+
+    user = await get_user_by_id(session, user_id)
+    if not user:
+        return None
+
+    return await update_user_optins(session, user, updates)

--- a/src/backend/base/langflow/services/database/models/user/model.py
+++ b/src/backend/base/langflow/services/database/models/user/model.py
@@ -19,6 +19,7 @@ class UserOptin(BaseModel):
     github_starred: bool = Field(default=False)
     dialog_dismissed: bool = Field(default=False)
     discord_clicked: bool = Field(default=False)
+    has_access: bool = Field(default=False)
     # Add more opt-in actions as needed
 
 
@@ -55,7 +56,12 @@ class UserCreate(SQLModel):
     username: str = Field()
     password: str = Field()
     optins: dict[str, Any] | None = Field(
-        default={"github_starred": False, "dialog_dismissed": False, "discord_clicked": False}
+        default={
+            "github_starred": False,
+            "dialog_dismissed": False,
+            "discord_clicked": False,
+            "has_access": False,
+        }
     )
 
 

--- a/src/backend/base/langflow/services/database/organisation.py
+++ b/src/backend/base/langflow/services/database/organisation.py
@@ -297,6 +297,7 @@ class OrganizationService:
             is_superuser=False,
             optins={
                 **UserOptin().model_dump(),
+                "has_access": False,
                 "skip_trial_access": False,
                 "trial_access_days": 7,
             },

--- a/src/frontend/src/components/billing/TrialAccessGate.tsx
+++ b/src/frontend/src/components/billing/TrialAccessGate.tsx
@@ -3,6 +3,7 @@ import { AuthContext } from "@/contexts/authContext";
 import { CustomLoadingPage } from "@/customization/components/custom-loading-page";
 import BillingPage from "@/pages/BillingPage";
 import useAuthStore from "@/stores/authStore";
+import { resolveHasAccess } from "@/utils/billing/hasAccess";
 
 const TrialAccessGate = ({
   children,
@@ -21,25 +22,10 @@ const TrialAccessGate = ({
     getUser();
   }, [getUser, isAuthenticated, requestStarted, userData]);
 
-  const hasTrialAccess = useMemo(() => {
-    if (!userData?.optins) {
-      return false;
-    }
-
-    const { skip_trial_access: skipTrial, trial_access_until: trialUntil } =
-      userData.optins;
-    if (skipTrial) {
-      return true;
-    }
-    if (!trialUntil) {
-      return false;
-    }
-    const trialDate = new Date(trialUntil);
-    if (Number.isNaN(trialDate.getTime())) {
-      return false;
-    }
-    return trialDate.getTime() > Date.now();
-  }, [userData?.optins]);
+  const hasTrialAccess = useMemo(
+    () => resolveHasAccess(userData?.optins),
+    [userData?.optins],
+  );
 
   if (!isAuthenticated) {
     return <>{children}</>;

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -632,6 +632,7 @@ export const CONTROL_NEW_USER = {
   is_active: false,
   is_superuser: false,
   optins: {
+    has_access: true,
     skip_trial_access: false,
     trial_access_until: DEFAULT_TRIAL_ACCESS_UNTIL,
     trial_access_days: 7,

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -162,6 +162,7 @@ export type changeUser = {
   password?: string;
   profile_image?: string;
   optins?: {
+    has_access?: boolean;
     github_starred?: boolean;
     discord_clicked?: boolean;
     dialog_dismissed?: boolean;
@@ -186,6 +187,7 @@ export type Users = {
   create_at: Date;
   updated_at: Date;
   optins?: {
+    has_access?: boolean;
     github_starred?: boolean;
     discord_clicked?: boolean;
     dialog_dismissed?: boolean;

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -439,6 +439,7 @@ export type UserInputType = {
     trial_access_days?: number;
     skip_trial_access?: boolean;
     trial_access_until?: string;
+    has_access?: boolean;
     github_starred?: boolean;
     discord_clicked?: boolean;
     dialog_dismissed?: boolean;

--- a/src/frontend/src/utils/billing/hasAccess.ts
+++ b/src/frontend/src/utils/billing/hasAccess.ts
@@ -1,0 +1,33 @@
+import { Users } from "@/types/api";
+
+const parseTrialUntil = (trialUntil?: string): number | null => {
+  if (!trialUntil) {
+    return null;
+  }
+  const parsed = new Date(trialUntil);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.getTime();
+};
+
+export const resolveHasAccess = (optins?: Users["optins"]): boolean => {
+  if (!optins) {
+    return false;
+  }
+
+  if (typeof optins.has_access === "boolean") {
+    return optins.has_access;
+  }
+
+  if (optins.skip_trial_access) {
+    return true;
+  }
+
+  const trialUntil = parseTrialUntil(optins.trial_access_until);
+  if (trialUntil === null) {
+    return false;
+  }
+
+  return trialUntil > Date.now();
+};


### PR DESCRIPTION
### Motivation
- Track whether users have active product access via a new `has_access` opt-in so UI gating can be decided server-side.
- Sync Stripe subscription events into user optins to keep access state consistent across payments and trials.
- Provide a secure webhook endpoint that verifies Stripe signatures and updates user subscription metadata.
- Minimize changes to existing code by adding a small billing helper stack and wiring it into existing user and billing routes.

### Description
- Add billing helpers at `src/backend/base/langflow/services/billing/access_control.py` to compute and persist `has_access` from trial dates and Stripe subscription status.
- Add a webhook endpoint `src/backend/base/langflow/api/v1/stripe_webhook.py` that verifies Stripe signatures and handles `checkout.session.completed` and subscription events to update user optins.
- Update checkout creation in `src/backend/base/langflow/api/v1/billing.py` to include subscription metadata (`user_id`) and `trial_period_days = 7` for Stripe sessions.
- Add `has_access` to the user optins model and defaults, protect access-related optins from non-admin edits, call `ensure_user_has_access` in `whoami`, and update frontend gating to use a new `resolveHasAccess` util (`src/frontend/src/utils/billing/hasAccess.ts`) with types and constants updated accordingly.

### Testing
- No automated tests were executed as part of this change.
- Basic static code changes were committed; integration with a live Stripe account and webhook will need to be validated in staging.
- Frontend type updates were applied to `src/frontend/src/types/*` to keep compile-time type safety intact; local build/tests were not run.
- Further end-to-end tests for the Stripe flow and webhook should be added in CI before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608090ccec832693bfc133b23f81f0)