### PR TITLE
Add public Terms, Privacy, and Refund policy pages (legacy frontend)

### DIFF
--- a/src/frontend/src/pages/LandingPage/index.tsx
+++ b/src/frontend/src/pages/LandingPage/index.tsx
@@ -528,10 +528,13 @@ export default function Landing(): JSX.Element {
             <div className="text-sm font-semibold">Legal & Company</div>
             <ul className="mt-3 space-y-2 text-sm text-white/70">
               <li>
-                <a href="#privacy">Privacy Policy</a>
+                <a href="/privacy-policy">Privacy Policy</a>
               </li>
               <li>
-                <a href="#terms">Terms of Service</a>
+                <a href="/terms-of-service">Terms of Service</a>
+              </li>
+              <li>
+                <a href="/refund-policy">Refund Policy</a>
               </li>
               <li>
                 <a href="#careers">Careers</a>

--- a/src/frontend/src/pages/PrivacyPolicyPage/index.tsx
+++ b/src/frontend/src/pages/PrivacyPolicyPage/index.tsx
@@ -1,0 +1,42 @@
+import { Link } from "react-router-dom";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-white text-gray-900">
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-12">
+        <div className="flex flex-col gap-2">
+          <Link to="/" className="text-sm font-medium text-blue-600">
+            ← Back to home
+          </Link>
+          <h1 className="text-3xl font-semibold">Privacy Policy</h1>
+          <p className="text-sm text-gray-500">Last updated: March 2025</p>
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Information we collect</h2>
+          <p>
+            We collect information you provide when creating an account,
+            subscribing, or contacting support. We also collect usage data to
+            operate and improve the platform.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Payment processing</h2>
+          <p>
+            Subscription payments are processed by Paddle. We do not store your
+            full payment card details on our servers.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Service delivery</h2>
+          <p>
+            The platform is delivered through automated systems. There are no
+            human-driven services involved in fulfilling the service.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/RefundPolicyPage/index.tsx
+++ b/src/frontend/src/pages/RefundPolicyPage/index.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+
+export default function RefundPolicyPage() {
+  return (
+    <div className="min-h-screen bg-white text-gray-900">
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-12">
+        <div className="flex flex-col gap-2">
+          <Link to="/" className="text-sm font-medium text-blue-600">
+            ← Back to home
+          </Link>
+          <h1 className="text-3xl font-semibold">Refund Policy</h1>
+          <p className="text-sm text-gray-500">Last updated: March 2025</p>
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Monthly subscriptions</h2>
+          <p>
+            Subscriptions are billed on a monthly recurring basis. Once a
+            payment is made, your subscription remains active until the end of
+            that billing month.
+          </p>
+          <p>
+            If you cancel, your subscription will stay active until the month
+            ends and will not renew for the following month.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">No refunds</h2>
+          <p>
+            All payments are final. We do not provide refunds after a payment is
+            made.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/TermsOfServicePage/index.tsx
+++ b/src/frontend/src/pages/TermsOfServicePage/index.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-screen bg-white text-gray-900">
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-12">
+        <div className="flex flex-col gap-2">
+          <Link to="/" className="text-sm font-medium text-blue-600">
+            ← Back to home
+          </Link>
+          <h1 className="text-3xl font-semibold">Terms of Service</h1>
+          <p className="text-sm text-gray-500">Last updated: March 2025</p>
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Service overview</h2>
+          <p>
+            Drag &amp; Drop AI Agent Builder provides an automated software
+            platform. There are no human-driven services involved in this
+            offering.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Subscriptions and billing</h2>
+          <p>
+            Plans are billed as monthly recurring subscriptions. Once a
+            subscription payment is made, access is active for the remainder of
+            that billing month.
+          </p>
+          <p>
+            If you cancel your subscription, it remains active until the end of
+            the current billing month and will not renew.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Refunds</h2>
+          <p>All payments are final. We do not offer refunds.</p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -88,6 +88,9 @@ const LoginAdminPage = lazy(() =>
 const AdminPage = lazy(() => import("./pages/AdminPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 const PlaygroundPage = lazy(() => import("./pages/Playground"));
+const TermsOfServicePage = lazy(() => import("./pages/TermsOfServicePage"));
+const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
+const RefundPolicyPage = lazy(() => import("./pages/RefundPolicyPage"));
 
 // ---- Router ----
 const router = createBrowserRouter(
@@ -371,6 +374,32 @@ const router = createBrowserRouter(
             </Route>
           </Route>
         </Route>
+
+        {/* Public policy routes */}
+        <Route
+          path="terms-of-service"
+          element={
+            <Suspense fallback={<LoadingPage />}>
+              <TermsOfServicePage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="privacy-policy"
+          element={
+            <Suspense fallback={<LoadingPage />}>
+              <PrivacyPolicyPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="refund-policy"
+          element={
+            <Suspense fallback={<LoadingPage />}>
+              <RefundPolicyPage />
+            </Suspense>
+          }
+        />
 
         {/* Auth routes */}
         <Route


### PR DESCRIPTION
### Motivation

- Provide Paddle with accessible legal pages by adding Terms of Service, Privacy Policy, and Refund Policy pages to the legacy frontend.
- Confirm that the offering is fully automated with no human-driven services and document subscription billing and the no-refund stance.
- Make the pages accessible to all visitors (authenticated and unauthenticated) from stable, legacy routes without touching the new frontend.
- Keep changes minimal by adding new files and only updating the legacy landing footer and router.

### Description

- Added three new pages: `src/frontend/src/pages/TermsOfServicePage/index.tsx`, `src/frontend/src/pages/PrivacyPolicyPage/index.tsx`, and `src/frontend/src/pages/RefundPolicyPage/index.tsx` that document service overview, billing, cancellation, and the no-refund policy.
- Exposed public routes in `src/frontend/src/routes.tsx` via lazy imports and new route entries at `/terms-of-service`, `/privacy-policy`, and `/refund-policy` so they are reachable without authentication.
- Updated the legacy landing page footer `src/frontend/src/pages/LandingPage/index.tsx` to link to the new policy URLs.
- Made only minimal edits to existing files and added the new pages under the legacy frontend as requested.

### Testing

- Ran `npm --prefix src/frontend install` to install frontend dependencies which completed successfully (audit warnings present).
- Started the legacy frontend dev server with `npm --prefix src/frontend run dev:docker` (Vite) and verified the server was reachable.
- Automated a Playwright script to navigate to `http://127.0.0.1:4173/terms-of-service` and capture a screenshot, which completed successfully and produced an artifact.
- No unit/integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661ee94be88326b3feec24fa75094e)