### PR TITLE
Update landing page pricing + footer links and use anchors on policy pages

### DIFF
--- a/src/frontend/src/pages/PrivacyPolicyPage/index.tsx
+++ b/src/frontend/src/pages/PrivacyPolicyPage/index.tsx
@@ -17,9 +17,7 @@ export default function PrivacyPolicyPage() {
               Visual AI Agents Builder
             </span>
           </Link>
-          <Link to="/" className="text-sm text-white/70 hover:text-white">
-            Back to home
-          </Link>
+          <a href="/">Back to home</a>
         </div>
       </header>
 

--- a/src/frontend/src/pages/RefundPolicyPage/index.tsx
+++ b/src/frontend/src/pages/RefundPolicyPage/index.tsx
@@ -17,9 +17,7 @@ export default function RefundPolicyPage() {
               Visual AI Agents Builder
             </span>
           </Link>
-          <Link to="/" className="text-sm text-white/70 hover:text-white">
-            Back to home
-          </Link>
+          <a href="/">Back to home</a>
         </div>
       </header>
 

--- a/src/frontend/src/pages/TermsOfServicePage/index.tsx
+++ b/src/frontend/src/pages/TermsOfServicePage/index.tsx
@@ -17,9 +17,7 @@ export default function TermsOfServicePage() {
               Visual AI Agents Builder
             </span>
           </Link>
-          <Link to="/" className="text-sm text-white/70 hover:text-white">
-            Back to home
-          </Link>
+          <a href="/">Back to home</a>
         </div>
       </header>
 

--- a/src/new-landingpage/src/LandingPage.tsx
+++ b/src/new-landingpage/src/LandingPage.tsx
@@ -484,57 +484,88 @@ export default function LandingPage(): JSX.Element {
 
       <section id="pricing" className="mx-auto max-w-7xl px-4 py-20">
         <div className="rounded-2xl border border-white/10 bg-[#0f1217] p-8">
-          <div className="grid gap-10 md:grid-cols-2">
-            <div>
-              <h2 className="text-2xl font-semibold">Fair, Transparent Pricing</h2>
-              <p className="mt-3 text-white/70">
-                Free (for developers) plus paid plans for teams and enterprise
-                with full security & support.
-              </p>
-              <ul className="mt-6 space-y-2 text-sm text-white/80">
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold">Simple, Scalable Pricing</h2>
+            <p className="mt-3 text-white/70">
+              Choose the plan that matches your team size and scale with
+              confidence.
+            </p>
+          </div>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            <div className="flex h-full flex-col rounded-xl border border-white/10 bg-[#0f1217] p-6">
+              <div className="text-sm text-white/60">Starter Pack</div>
+              <div className="mt-2 text-3xl font-semibold">$20 USD</div>
+              <div className="mt-1 text-sm text-white/70">7-day free trial</div>
+              <ul className="mt-4 space-y-2 text-sm text-white/80">
                 <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Unlimited public flows
+                  <CheckIcon className="h-4 w-4" />Shared database
                 </li>
                 <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Team seats & organization
-                  tenancies
+                  <CheckIcon className="h-4 w-4" />Standard rate limits
                 </li>
                 <li className="flex items-center gap-2">
-                  <CheckIcon className="h-4 w-4" />Enterprise support & SLA
+                  <CheckIcon className="h-4 w-4" />Core visual builder features
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Community support
                 </li>
               </ul>
+              <a
+                href="#signup"
+                className="mt-6 inline-block rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900"
+              >
+                Start Free Trial
+              </a>
             </div>
-
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
-                <div className="text-sm text-white/60">Starter</div>
-                <div className="mt-2 text-3xl font-semibold">Free</div>
-                <p className="mt-2 text-sm text-white/70">
-                  For personal projects, hobbyists. All core features except
-                  enterprise.
-                </p>
-                <a
-                  href="#signup"
-                  className="mt-4 inline-block rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900"
-                >
-                  Get Started Free
-                </a>
-              </div>
-
-              <div className="rounded-xl border border-white/10 bg-[#0f1217] p-6">
-                <div className="text-sm text-white/60">Enterprise</div>
-                <div className="mt-2 text-3xl font-semibold">Contact Us</div>
-                <p className="mt-2 text-sm text-white/70">
-                  Includes SSO, data isolation, custom deployment, dedicated
-                  support & SLAs.
-                </p>
-                <a
-                  href="#contact"
-                  className="mt-4 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
-                >
-                  Contact Sales
-                </a>
-              </div>
+            <div className="flex h-full flex-col rounded-xl border border-white/10 bg-[#0f1217] p-6">
+              <div className="text-sm text-white/60">Pro Pack</div>
+              <div className="mt-2 text-3xl font-semibold">$50 USD</div>
+              <div className="mt-1 text-sm text-white/70">No trial period</div>
+              <ul className="mt-4 space-y-2 text-sm text-white/80">
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Separate database
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Highly enabled rate limits
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Team collaboration tools
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Priority email support
+                </li>
+              </ul>
+              <a
+                href="#signup"
+                className="mt-6 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
+              >
+                Upgrade to Pro
+              </a>
+            </div>
+            <div className="flex h-full flex-col rounded-xl border border-white/10 bg-[#0f1217] p-6">
+              <div className="text-sm text-white/60">Enterprise Pack</div>
+              <div className="mt-2 text-3xl font-semibold">Talk to sales</div>
+              <div className="mt-1 text-sm text-white/70">Custom pricing</div>
+              <ul className="mt-4 space-y-2 text-sm text-white/80">
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Dedicated environments
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Custom security & compliance
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />SSO and role-based access
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckIcon className="h-4 w-4" />Premium SLA & support
+                </li>
+              </ul>
+              <a
+                href="#contact"
+                className="mt-6 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
+              >
+                Contact Sales
+              </a>
             </div>
           </div>
         </div>
@@ -625,10 +656,13 @@ export default function LandingPage(): JSX.Element {
             <div className="text-sm font-semibold">Legal & Company</div>
             <ul className="mt-3 space-y-2 text-sm text-white/70">
               <li>
-                <a href="#privacy">Privacy Policy</a>
+                <a href="/privacy-policy">Privacy Policy</a>
               </li>
               <li>
-                <a href="#terms">Terms of Service</a>
+                <a href="/terms-of-service">Terms of Service</a>
+              </li>
+              <li>
+                <a href="/refund-policy">Refund Policy</a>
               </li>
               <li>
                 <a href="#careers">Careers</a>


### PR DESCRIPTION
### Motivation
- Bring the new landing page into parity with the updated pricing layout and CTAs used on the old landing page. 
- Provide simple, direct back navigation on legal pages by using plain anchors instead of client-side `Link`s. 
- Ensure the footer links point to canonical policy routes and include a Refund Policy entry.

### Description
- Replaced the single pricing teaser with a three-card pricing layout (`Starter Pack`, `Pro Pack`, `Enterprise Pack`) in `src/new-landingpage/src/LandingPage.tsx` with updated copy and CTAs. 
- Updated footer legal links in the new landing page to use direct routes: `/privacy-policy`, `/terms-of-service`, and `/refund-policy`. 
- Replaced `Link to="/"` with plain `<a href="/">Back to home</a>` in `src/frontend/src/pages/PrivacyPolicyPage/index.tsx`, `RefundPolicyPage/index.tsx`, and `TermsOfServicePage/index.tsx` to provide direct navigation. 
- Committed the `LandingPage.tsx` changes to the new landing page project.

### Testing
- Ran `npm install` in `src/new-landingpage` which completed successfully (audit reported vulnerabilities to address separately). 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4174` and confirmed Vite reported the site as served. 
- Attempted a Playwright script to capture a screenshot of the updated pricing section, but the Chromium run failed with a headless crash so the screenshot step failed. 
- No unit test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696640cf616c832680e50ef563dd7620)