### PR TITLE
Remove Suspense wrappers from public policy routes

### DIFF
--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -378,27 +378,15 @@ const router = createBrowserRouter(
         {/* Public policy routes */}
         <Route
           path="terms-of-service"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <TermsOfServicePage />
-            </Suspense>
-          }
+          element={<TermsOfServicePage />}
         />
         <Route
           path="privacy-policy"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <PrivacyPolicyPage />
-            </Suspense>
-          }
+          element={<PrivacyPolicyPage />}
         />
         <Route
           path="refund-policy"
-          element={
-            <Suspense fallback={<LoadingPage />}>
-              <RefundPolicyPage />
-            </Suspense>
-          }
+          element={<RefundPolicyPage />}
         />
 
         {/* Auth routes */}


### PR DESCRIPTION
### Motivation
- The public policy pages were wrapped in `Suspense` with a `LoadingPage` fallback but do not require lazy-loading behavior. 
- Simplify routing to render static policy pages directly and avoid unnecessary loading fallbacks.

### Description
- Removed `Suspense` wrappers for `TermsOfServicePage`, `PrivacyPolicyPage`, and `RefundPolicyPage` in `src/frontend/src/routes.tsx` so they are now rendered as `element={<TermsOfServicePage />}` (and equivalents).
- The change updates only `src/frontend/src/routes.tsx` and reduces the Suspense-related boilerplate around these routes.

### Testing
- No automated tests were run for this change.
- CI/build was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696659f75058832686d12373d570acb2)