### PR TITLE
Remove Enterprise 'Custom pricing' subtext on landing pages

### DIFF
--- a/src/frontend/src/pages/LandingPage/index.tsx
+++ b/src/frontend/src/pages/LandingPage/index.tsx
@@ -468,8 +468,7 @@ export default function Landing(): JSX.Element {
             </div>
             <div className="flex h-full flex-col rounded-xl border border-white/10 bg-[#0f1217] p-6">
               <div className="text-sm text-white/60">Enterprise Pack</div>
-              <div className="mt-2 text-3xl font-semibold">Talk to sales</div>
-              <div className="mt-1 text-sm text-white/70">Custom pricing</div>
+              <div className="mt-2 text-3xl font-semibold">$120/seat/month</div>
               <ul className="mt-4 space-y-2 text-sm text-white/80">
                 <li className="flex items-center gap-2">
                   <CheckIcon className="h-4 w-4" />Dedicated environments
@@ -488,7 +487,7 @@ export default function Landing(): JSX.Element {
                 href="#contact"
                 className="mt-6 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
               >
-                Contact Sales
+                Upgrade to Enterprise
               </a>
             </div>
           </div>

--- a/src/new-landingpage/src/LandingPage.tsx
+++ b/src/new-landingpage/src/LandingPage.tsx
@@ -544,8 +544,7 @@ export default function LandingPage(): JSX.Element {
             </div>
             <div className="flex h-full flex-col rounded-xl border border-white/10 bg-[#0f1217] p-6">
               <div className="text-sm text-white/60">Enterprise Pack</div>
-              <div className="mt-2 text-3xl font-semibold">Talk to sales</div>
-              <div className="mt-1 text-sm text-white/70">Custom pricing</div>
+              <div className="mt-2 text-3xl font-semibold">$120/seat/month</div>
               <ul className="mt-4 space-y-2 text-sm text-white/80">
                 <li className="flex items-center gap-2">
                   <CheckIcon className="h-4 w-4" />Dedicated environments
@@ -564,7 +563,7 @@ export default function LandingPage(): JSX.Element {
                 href="#contact"
                 className="mt-6 inline-block rounded-lg border border-white/15 px-4 py-2 text-sm"
               >
-                Contact Sales
+                Upgrade to Enterprise
               </a>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Keep the Enterprise pricing display concise and consistent after updating the price and CTA by removing the redundant “Custom pricing” subtext on both landing pages.

### Description
- Deleted the `div` containing the `Custom pricing` text from the Enterprise pricing card in `src/frontend/src/pages/LandingPage/index.tsx`.
- Deleted the matching `div` in `src/new-landingpage/src/LandingPage.tsx` to keep the new landing page aligned with the primary one.
- Left the updated price (`$120/seat/month`) and CTA (`Upgrade to Enterprise`) intact.

### Testing
- Committed the changes with `git commit` which completed successfully.
- Attempted a Playwright screenshot of `http://localhost:3000/#pricing` but the run failed with `net::ERR_EMPTY_RESPONSE` because no local server responded, so no visual test could be captured.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b426df2408326803e7b7bf144ed54)