### PR TITLE
Update refund policy copy on RefundPolicyPage

### DIFF
--- a/src/frontend/src/pages/RefundPolicyPage/index.tsx
+++ b/src/frontend/src/pages/RefundPolicyPage/index.tsx
@@ -65,8 +65,7 @@ export default function RefundPolicyPage() {
             acknowledge that the service has begun. Once access has started, you may cancel
             your subscription at any time through the billing portal; however, refunds,
             non-refunds, and service continuation are governed by the terms outlined in this
-            policy. Service will continue until the end of the current billing period unless
-            otherwise stated.
+            policy.
           </p>
         </section>
 
@@ -79,7 +78,8 @@ export default function RefundPolicyPage() {
             Subscription renewals are non-refundable. We do not provide refunds for partially
             used billing periods or for unused time after cancellation. Your service will
             remain active for the remainder of the billing period for which payment has been
-            made.
+            made for renewals for the months after the first month initial subscription
+            purchase
           </p>
         </section>
 


### PR DESCRIPTION
### Motivation

- Align the on-site Refund Policy copy with the updated March 2025 wording, clarifying the digital service acknowledgement and renewal/refund scope.

### Description

- Updated the refund text in `src/frontend/src/pages/RefundPolicyPage/index.tsx` to remove a redundant sentence in the Digital Service Acknowledgement section and to adjust the Renewals & Ongoing Subscription Payments paragraph.
- Change set includes small content edits (3 insertions, 3 deletions) to the Refund Policy page copy.

### Testing

- Ran `npm install` in the `src/frontend` workspace to install dependencies, which completed with warnings but succeeded.
- Started the local dev server with `npm run dev:docker` and verified the page by running a Playwright script that loaded `http://127.0.0.1:3000/refund-policy` and captured a screenshot, which succeeded.
- No unit or integration test suite was executed for this content-only change (no `npm test` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b44b4fdd88326bbb1509fb559e222)