### PR TITLE
Simplify noop send_message signature

### DIFF
--- a/src/lfx/src/lfx/base/tools/component_tool.py
+++ b/src/lfx/src/lfx/base/tools/component_tool.py
@@ -51,6 +51,7 @@ async def send_message_noop(
     id_: str | None = None,  # noqa: ARG001
     *,
     allow_markdown: bool = True,  # noqa: ARG001
+    **_: object,
 ) -> Message:
     """No-op implementation of send_message."""
     return message


### PR DESCRIPTION
### Motivation
- Avoid a large refactor and keep the change minimal by making the noop tolerate newer kwargs (like `skip_db_update`) instead of introducing a separate module.  
- `skip_db_update` is sent during agent streaming to avoid repeated DB writes and must be accepted by patched/no-op `send_message` implementations to prevent runtime errors.

### Description
- Restored a local noop in `src/lfx/src/lfx/base/tools/component_tool.py` named `send_message_noop` and added a catch-all `**_: object` parameter so it accepts extra keyword arguments (including `skip_db_update`).  
- Removed the separate module `src/lfx/src/lfx/base/tools/send_message_noop.py` and the import that referenced it to keep the change minimal.  
- The `patch_components_send_message` and `_patch_send_message_decorator` logic remain unchanged and now assign the local `send_message_noop` to the component.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd9196dcc8326a520b89192b4ccae)