### PR TITLE
Playground: show user messages immediately with optimistic UI

### DIFF
--- a/src/frontend/src/modals/IOModal/playground-modal.tsx
+++ b/src/frontend/src/modals/IOModal/playground-modal.tsx
@@ -1,6 +1,7 @@
 //import LangflowLogoColor from "@/assets/LangflowLogocolor.svg?react";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
 import { useShallow } from "zustand/react/shallow";
 import ThemeButtons from "@/components/core/appHeaderComponent/components/ThemeButtons";
 import { useGetMessagesQuery } from "@/controllers/API/queries/messages";
@@ -43,7 +44,6 @@ export default function IOModal({
   const outputs = useFlowStore((state) => state.outputs);
   const nodes = useFlowStore((state) => state.nodes);
   const buildFlow = useFlowStore((state) => state.buildFlow);
-  const setIsBuilding = useFlowStore((state) => state.setIsBuilding);
   const isBuilding = useFlowStore((state) => state.isBuilding);
   const newChatOnPlayground = useFlowStore(
     (state) => state.newChatOnPlayground,
@@ -75,6 +75,8 @@ export default function IOModal({
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const deleteSession = useMessagesStore((state) => state.deleteSession);
+  const addMessage = useMessagesStore((state) => state.addMessage);
+  const removeMessage = useMessagesStore((state) => state.removeMessage);
   const currentFlowId = useGetFlowId();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
@@ -209,22 +211,61 @@ export default function IOModal({
       files?: string[];
     }): Promise<void> => {
       if (isBuilding) return;
+      const optimisticMessage =
+        playgroundPage && (chatValue || (files && files.length > 0))
+          ? {
+              id: `optimistic-${uuid()}`,
+              text: chatValue,
+              sender: "User",
+              sender_name: "User",
+              session_id: sessionId,
+              timestamp: new Date().toISOString(),
+              files: files ?? [],
+              edit: false,
+              background_color: "",
+              text_color: "",
+              flow_id: currentFlowId,
+              properties: { optimistic: true },
+            }
+          : null;
+      if (optimisticMessage) {
+        addMessage(optimisticMessage);
+      }
       setChatValue("");
-      for (let i = 0; i < repeat; i++) {
-        await buildFlow({
-          input_value: chatValue,
-          startNodeId: chatInput?.id,
-          files: files,
-          silent: true,
-          session: sessionId,
-          eventDelivery: eventDeliveryConfig,
-        }).catch((err) => {
-          console.error(err);
-          throw err;
-        });
+      try {
+        for (let i = 0; i < repeat; i++) {
+          await buildFlow({
+            input_value: chatValue,
+            startNodeId: chatInput?.id,
+            files: files,
+            silent: true,
+            session: sessionId,
+            eventDelivery: eventDeliveryConfig,
+          }).catch((err) => {
+            console.error(err);
+            throw err;
+          });
+        }
+      } catch (error) {
+        if (optimisticMessage) {
+          removeMessage(optimisticMessage);
+        }
+        throw error;
       }
     },
-    [isBuilding, setIsBuilding, chatValue, chatInput?.id, sessionId, buildFlow],
+    [
+      isBuilding,
+      chatValue,
+      chatInput?.id,
+      sessionId,
+      buildFlow,
+      playgroundPage,
+      addMessage,
+      removeMessage,
+      currentFlowId,
+      eventDeliveryConfig,
+      setChatValue,
+    ],
   );
 
   useEffect(() => {

--- a/src/frontend/src/stores/messagesStore.ts
+++ b/src/frontend/src/stores/messagesStore.ts
@@ -31,6 +31,23 @@ export const useMessagesStore = create<MessagesStoreType>((set, get) => ({
       }
       return;
     }
+    if (message.sender === "User") {
+      const messages = get().messages;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const candidate = messages[i];
+        if (
+          candidate.sender === "User" &&
+          candidate.properties?.optimistic &&
+          candidate.session_id === message.session_id &&
+          candidate.text === message.text
+        ) {
+          const updatedMessages = [...messages];
+          updatedMessages[i] = message;
+          set(() => ({ messages: updatedMessages }));
+          return;
+        }
+      }
+    }
     if (message.sender === "Machine") {
       set(() => ({ displayLoadingMessage: false }));
     }


### PR DESCRIPTION
### Motivation
- Users reported that messages typed in the playground only become visible after the AI response arrives, so the intent is to display the user's question immediately when they press Enter while keeping server answers intact.

### Description
- Add optimistic user message creation in `src/frontend/src/modals/IOModal/playground-modal.tsx` (uses `uuid` and `addMessage`) so the input is shown instantly before calling `buildFlow`.
- Roll back optimistic messages on send failure by calling `removeMessage` in the `catch` block of `sendMessage` to avoid stale UI state.
- Update `src/frontend/src/stores/messagesStore.ts` to detect and replace optimistic `User` messages with the real server message when it arrives by matching `session_id`, `text`, and `properties.optimistic` to avoid duplicates and preserve streaming behavior.
- Clean up an unused `setIsBuilding` selector and adjust `sendMessage` hook dependencies accordingly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c81c17da08326ab77540b5218bd12)