### PR TITLE
Show optimistic chat messages in playground and fix new chat/session selection

### DIFF
--- a/src/frontend/src/modals/IOModal/playground-modal.tsx
+++ b/src/frontend/src/modals/IOModal/playground-modal.tsx
@@ -1,6 +1,7 @@
 //import LangflowLogoColor from "@/assets/LangflowLogocolor.svg?react";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import ShortUniqueId from "short-unique-id";
 import { useShallow } from "zustand/react/shallow";
 import ThemeButtons from "@/components/core/appHeaderComponent/components/ThemeButtons";
 import { useGetMessagesQuery } from "@/controllers/API/queries/messages";
@@ -75,6 +76,7 @@ export default function IOModal({
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const deleteSession = useMessagesStore((state) => state.deleteSession);
+  const addMessage = useMessagesStore((state) => state.addMessage);
   const currentFlowId = useGetFlowId();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
@@ -88,7 +90,6 @@ export default function IOModal({
   const {
     data: sessionsFromDb,
     isLoading: sessionsLoading,
-    refetch: refetchSessions,
   } = useGetSessionsFromFlowQuery(
     {
       id: currentFlowId,
@@ -209,6 +210,28 @@ export default function IOModal({
       files?: string[];
     }): Promise<void> => {
       if (isBuilding) return;
+      const activeSessionId = visibleSession ?? sessionId;
+      const shouldAddOptimisticMessage =
+        chatValue !== "" || (files && files.length > 0);
+      if (shouldAddOptimisticMessage) {
+        const uid = new ShortUniqueId();
+        addMessage({
+          id: `optimistic-${uid.randomUUID(10)}`,
+          flow_id: currentFlowId,
+          text: chatValue,
+          sender: "User",
+          sender_name: "User",
+          session_id: activeSessionId,
+          timestamp: new Date().toISOString(),
+          files: files ?? [],
+          edit: false,
+          background_color: "",
+          text_color: "",
+          properties: {
+            optimistic: true,
+          },
+        });
+      }
       setChatValue("");
       for (let i = 0; i < repeat; i++) {
         await buildFlow({
@@ -216,7 +239,7 @@ export default function IOModal({
           startNodeId: chatInput?.id,
           files: files,
           silent: true,
-          session: sessionId,
+          session: activeSessionId,
           eventDelivery: eventDeliveryConfig,
         }).catch((err) => {
           console.error(err);
@@ -224,7 +247,18 @@ export default function IOModal({
         });
       }
     },
-    [isBuilding, setIsBuilding, chatValue, chatInput?.id, sessionId, buildFlow],
+    [
+      addMessage,
+      buildFlow,
+      chatInput?.id,
+      chatValue,
+      currentFlowId,
+      eventDeliveryConfig,
+      isBuilding,
+      sessionId,
+      setChatValue,
+      visibleSession,
+    ],
   );
 
   useEffect(() => {
@@ -232,39 +266,45 @@ export default function IOModal({
       window.sessionStorage.setItem(currentFlowId, JSON.stringify(messages));
     }
     if (newChatOnPlayground && !sessionsLoading) {
-      const handleRefetchAndSetSession = async () => {
-        try {
-          const result = await refetchSessions();
-          if (result.data?.sessions && result.data.sessions.length > 0) {
-            setvisibleSession(
-              result.data.sessions[result.data.sessions.length - 1],
-            );
-          }
-        } catch (error) {
-          console.error("Error refetching sessions:", error);
+      const newSessionId = createNewSessionName();
+      setSessions((prevSessions) => {
+        if (prevSessions.includes(newSessionId)) {
+          return prevSessions;
         }
-      };
-
-      handleRefetchAndSetSession();
+        return [newSessionId, ...prevSessions];
+      });
+      setvisibleSession(newSessionId);
       setNewChatOnPlayground(false);
     }
-  }, [messages, playgroundPage]);
+  }, [
+    currentFlowId,
+    messages,
+    newChatOnPlayground,
+    playgroundPage,
+    sessionsLoading,
+    setNewChatOnPlayground,
+  ]);
 
   useEffect(() => {
     if (!visibleSession) {
-      setSessionId(createNewSessionName());
-      setCurrentSessionId(currentFlowId);
-    } else if (visibleSession) {
-      setSessionId(visibleSession);
-      setCurrentSessionId(visibleSession);
-      if (selectedViewField?.type === "Session") {
-        setSelectedViewField({
-          id: visibleSession,
-          type: "Session",
-        });
+      if (newChatOnPlayground) {
+        return;
       }
+      const newSessionId = createNewSessionName();
+      setSessionId(newSessionId);
+      setCurrentSessionId(newSessionId);
+      setvisibleSession(newSessionId);
+      return;
     }
-  }, [visibleSession]);
+    setSessionId(visibleSession);
+    setCurrentSessionId(visibleSession);
+    if (selectedViewField?.type === "Session") {
+      setSelectedViewField({
+        id: visibleSession,
+        type: "Session",
+      });
+    }
+  }, [newChatOnPlayground, visibleSession]);
 
   const setPlaygroundScrollBehaves = useUtilityStore(
     (state) => state.setPlaygroundScrollBehaves,

--- a/src/frontend/src/stores/messagesStore.ts
+++ b/src/frontend/src/stores/messagesStore.ts
@@ -16,6 +16,22 @@ export const useMessagesStore = create<MessagesStoreType>((set, get) => ({
     set(() => ({ messages: messages }));
   },
   addMessage: (message) => {
+    if (!message.properties?.optimistic && message.sender === "User") {
+      const optimisticIndex = get().messages.findIndex(
+        (msg) =>
+          msg.properties?.optimistic &&
+          msg.sender === "User" &&
+          msg.session_id === message.session_id &&
+          msg.flow_id === message.flow_id &&
+          msg.text === message.text,
+      );
+      if (optimisticIndex !== -1) {
+        const updatedMessages = [...get().messages];
+        updatedMessages[optimisticIndex] = message;
+        set(() => ({ messages: updatedMessages }));
+        return;
+      }
+    }
     const existingMessage = get().messages.find((msg) => msg.id === message.id);
     if (existingMessage) {
       // Check if this is a streaming partial message (state: "partial")


### PR DESCRIPTION
### Motivation
- Make user input appear immediately in the playground by inserting optimistic user messages and avoid duplicate entries when the server response arrives.
- Ensure the "New Chat" action actually creates and selects a new session instead of falling back to prior sessions or leaving the visible session unset.
- Keep build/execution and message reconciliation aligned with the selected/active session so messages are shown in the correct session.

### Description
- Add optimistic user messages in the playground `sendMessage` flow by creating an optimistic message with `id` prefixed `optimistic-` and `properties.optimistic` and target the active session via `visibleSession ?? sessionId`, and pass the same `activeSessionId` to `buildFlow` (changes in `src/modals/IOModal/playground-modal.tsx`).
- Change the new-chat flow to generate a new session id with `createNewSessionName`, prepend it to `sessions`, set it as `visibleSession`, and avoid refetching sessions from the backend; adjust the `visibleSession` effect to not auto-create a session while `newChatOnPlayground` is in progress (changes in `src/modals/IOModal/playground-modal.tsx`).
- Reconcile optimistic messages in `useMessagesStore.addMessage` by replacing an existing optimistic user message that matches `flow_id`, `session_id`, `text`, and `sender` with the authoritative server message to prevent duplicate user messages (changes in `src/stores/messagesStore.ts`).

### Testing
- No automated tests were executed for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca395fc748326a00e4bb0ac93a276)