### PR TITLE
Add optional SQL credentials inputs and URI builder for SQLAgentComponent

### DIFF
--- a/src/lfx/src/lfx/components/langchain_utilities/sql.py
+++ b/src/lfx/src/lfx/components/langchain_utilities/sql.py
@@ -4,8 +4,14 @@ from langchain_community.agent_toolkits.sql.base import create_sql_agent
 from langchain_community.utilities import SQLDatabase
 
 from lfx.base.agents.agent import LCAgentComponent
-from lfx.inputs.inputs import HandleInput, MessageTextInput
+from lfx.inputs.inputs import (
+    HandleInput,
+    MessageTextInput,
+    SecretStrInput,
+    StrInput,
+)
 from lfx.io import Output
+from urllib.parse import urlparse, urlunparse
 
 
 class SQLAgentComponent(LCAgentComponent):
@@ -17,6 +23,18 @@ class SQLAgentComponent(LCAgentComponent):
         *LCAgentComponent.get_base_inputs(),
         HandleInput(name="llm", display_name="Language Model", input_types=["LanguageModel"], required=True),
         MessageTextInput(name="database_uri", display_name="Database URI", required=True),
+        StrInput(
+            name="username",
+            display_name="Username",
+            required=False,
+            info="Database username (leave empty if credentials are in URI)",
+        ),
+        SecretStrInput(
+            name="password",
+            display_name="Password",
+            required=False,
+            info="Database password (leave empty if credentials are in URI)",
+        ),
         HandleInput(
             name="extra_tools",
             display_name="Extra Tools",
@@ -31,8 +49,31 @@ class SQLAgentComponent(LCAgentComponent):
         Output(display_name="Agent", name="agent", method="build_agent", tool_mode=False),
     ]
 
+    def _build_database_uri(self) -> str:
+        """
+        Construct the database URI either from the full URI or by combining
+        the base URI with separate username and password.
+        """
+        base_uri = self.database_uri
+
+        if self.username and self.password:
+            parsed = urlparse(base_uri)
+
+            if parsed.hostname:
+                netloc = f"{self.username}:{self.password}@{parsed.hostname}"
+                if parsed.port:
+                    netloc += f":{parsed.port}"
+            else:
+                netloc = f"{self.username}:{self.password}@{parsed.netloc}"
+
+            parsed = parsed._replace(netloc=netloc)
+            return urlunparse(parsed)
+
+        return base_uri
+
     def build_agent(self) -> AgentExecutor:
-        db = SQLDatabase.from_uri(self.database_uri)
+        database_uri = self._build_database_uri()
+        db = SQLDatabase.from_uri(database_uri)
         toolkit = SQLDatabaseToolkit(db=db, llm=self.llm)
         agent_args = self.get_agent_kwargs()
         agent_args["max_iterations"] = agent_args["agent_executor_kwargs"]["max_iterations"]


### PR DESCRIPTION
### Motivation

- Allow supplying database credentials separately from the URI when constructing the SQL agent to support environments where credentials are provided via UI fields rather than embedded in the URI.

### Description

- Added optional `username` (`StrInput`) and `password` (`SecretStrInput`) inputs to `SQLAgentComponent` to accept standalone credentials.
- Implemented `_build_database_uri()` which parses `database_uri` and injects `username:password` into the URI `netloc` when both credentials are provided using `urlparse`/`urlunparse`.
- Updated `build_agent()` to use the constructed `database_uri` before calling `SQLDatabase.from_uri()` so the toolkit is initialized with credentials when supplied.
- Changes made in `src/lfx/src/lfx/components/langchain_utilities/sql.py` and new imports for `StrInput`, `SecretStrInput`, `urlparse`, and `urlunparse` were added.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f550547008326a4e2a443bf6cf3b0)