### PR TITLE
Support separate DB credentials for SQL agent and build URI dynamically

### DIFF
--- a/src/lfx/src/lfx/components/langchain_utilities/sql.py
+++ b/src/lfx/src/lfx/components/langchain_utilities/sql.py
@@ -1,10 +1,12 @@
+from urllib.parse import urlparse, urlunparse
+
 from langchain.agents import AgentExecutor
 from langchain_community.agent_toolkits import SQLDatabaseToolkit
 from langchain_community.agent_toolkits.sql.base import create_sql_agent
 from langchain_community.utilities import SQLDatabase
 
 from lfx.base.agents.agent import LCAgentComponent
-from lfx.inputs.inputs import HandleInput, MessageTextInput
+from lfx.inputs.inputs import HandleInput, MessageTextInput, SecretStrInput, StrInput
 from lfx.io import Output
 
 
@@ -16,7 +18,24 @@ class SQLAgentComponent(LCAgentComponent):
     inputs = [
         *LCAgentComponent.get_base_inputs(),
         HandleInput(name="llm", display_name="Language Model", input_types=["LanguageModel"], required=True),
-        MessageTextInput(name="database_uri", display_name="Database URI", required=True),
+        MessageTextInput(
+            name="database_uri",
+            display_name="Database URI",
+            required=True,
+            info="Full URI with credentials OR URI without credentials (if using separate username/password fields)",
+        ),
+        StrInput(
+            name="username",
+            display_name="Username",
+            required=False,
+            info="Database username (leave empty if credentials are in URI)",
+        ),
+        SecretStrInput(
+            name="password",
+            display_name="Password",
+            required=False,
+            info="Database password (leave empty if credentials are in URI)",
+        ),
         HandleInput(
             name="extra_tools",
             display_name="Extra Tools",
@@ -31,8 +50,35 @@ class SQLAgentComponent(LCAgentComponent):
         Output(display_name="Agent", name="agent", method="build_agent", tool_mode=False),
     ]
 
+    def _build_database_uri(self) -> str:
+        """
+        Construct the database URI either from the full URI or by combining
+        the base URI with separate username and password.
+        """
+        base_uri = self.database_uri
+
+        if self.username and self.password:
+            parsed = urlparse(base_uri)
+
+            if parsed.hostname:
+                hostname = parsed.hostname
+                if ":" in hostname:
+                    hostname = f"[{hostname}]"
+
+                netloc = f"{self.username}:{self.password}@{hostname}"
+                if parsed.port:
+                    netloc += f":{parsed.port}"
+            else:
+                netloc = f"{self.username}:{self.password}@{parsed.netloc}"
+
+            parsed = parsed._replace(netloc=netloc)
+            return urlunparse(parsed)
+
+        return base_uri
+
     def build_agent(self) -> AgentExecutor:
-        db = SQLDatabase.from_uri(self.database_uri)
+        database_uri = self._build_database_uri()
+        db = SQLDatabase.from_uri(database_uri)
         toolkit = SQLDatabaseToolkit(db=db, llm=self.llm)
         agent_args = self.get_agent_kwargs()
         agent_args["max_iterations"] = agent_args["agent_executor_kwargs"]["max_iterations"]


### PR DESCRIPTION
### Motivation
- Allow supplying database credentials either embedded in the URI or separately via dedicated fields so users can avoid exposing credentials in the URI.
- Automatically construct a valid connection URI when `username`/`password` are provided to make `SQLAgent` easier to configure for different environments.

### Description
- Added optional `StrInput` `username` and `SecretStrInput` `password` inputs to the `SQLAgentComponent` and updated the `database_uri` `MessageTextInput` to clarify credential options.
- Implemented a helper method `def _build_database_uri(self) -> str` that parses `database_uri` and injects `username`/`password` when present, including IPv6 host handling and preserving ports, and returns the reconstructed URI.
- Updated `build_agent` to use the constructed URI via `_build_database_uri()` before creating the `SQLDatabase` and the `SQLDatabaseToolkit`.
- Added `urlparse`/`urlunparse` imports and kept existing agent argument handling (`get_agent_kwargs()` and `create_sql_agent`) unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f60b1d5fc8326b3c62e345ed29118)