### PR TITLE
Add configurable webhook response handling

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -11,7 +11,7 @@ import orjson
 import sqlalchemy as sa
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Request, UploadFile, status
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from lfx.custom.custom_component.component import Component
 from lfx.custom.utils import (
     add_code_field_to_build_config,
@@ -47,7 +47,10 @@ from langflow.schema.graph import Tweaks
 from langflow.services.auth.utils import api_key_security, get_current_active_user, get_webhook_user
 from langflow.services.cache.utils import save_uploaded_file
 from langflow.services.database.models.flow.model import Flow, FlowRead
-from langflow.services.database.models.flow.utils import get_all_webhook_components_in_flow
+from langflow.services.database.models.flow.utils import (
+    get_all_webhook_components_in_flow,
+    get_configurable_webhook_response,
+)
 from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import get_session_service, get_settings_service, get_telemetry_service
 from langflow.services.telemetry.schema import RunPayload
@@ -468,6 +471,9 @@ async def webhook_run_flow(
 
     # Get the appropriate user for webhook execution based on auth settings
     webhook_user = await get_webhook_user(flow_id_or_name, request)
+    response_config = get_configurable_webhook_response(flow.data)
+    response_payload: dict | list | None = None
+    response_status_code: int | None = None
 
     try:
         try:
@@ -502,9 +508,24 @@ async def webhook_run_flow(
                 input_request=input_request,
                 api_key_user=webhook_user,
             )
-        except Exception as exc:
-            error_msg = str(exc)
-            raise HTTPException(status_code=500, detail=error_msg) from exc
+    except Exception as exc:
+        error_msg = str(exc)
+        raise HTTPException(status_code=500, detail=error_msg) from exc
+
+    # If configurable response is set, evaluate it immediately
+    if response_config:
+        try:
+            from langflow.services.webhook.response_evaluator import evaluate_configurable_webhook_response
+
+            response_status_code, response_payload = evaluate_configurable_webhook_response(
+                response_config,
+                data,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Fail-safe: never break webhook execution; fall back to default accepted
+            logger.warning(f"Failed to evaluate configurable webhook response: {exc}")
+            response_status_code = int(HTTPStatus.ACCEPTED)
+            response_payload = {"message": "Task started in the background", "status": "in progress"}
     finally:
         background_tasks.add_task(
             telemetry_service.log_package_run,
@@ -515,6 +536,10 @@ async def webhook_run_flow(
                 run_error_message=error_msg,
             ),
         )
+
+    # Return configured response if available
+    if response_payload is not None:
+        return JSONResponse(status_code=response_status_code, content=response_payload)
 
     return {"message": "Task started in the background", "status": "in progress"}
 

--- a/src/backend/base/langflow/services/database/models/flow/utils.py
+++ b/src/backend/base/langflow/services/database/models/flow/utils.py
@@ -40,3 +40,37 @@ def get_outdated_components(flow: Flow):
         if value != lf_version:
             outdated_components.append(key)
     return outdated_components
+
+
+def get_configurable_webhook_response(flow_data: dict | None) -> dict | None:
+    """Get configurable webhook response settings from flow data.
+
+    Supports two modes:
+      1) Conditional mode:
+         - response_rules (JSON list)
+         - default_response (JSON object)
+      2) Legacy static mode:
+         - response_status_code
+         - response_body
+
+    If use_default_response is True => returns None (meaning: use default 202 response).
+    """
+    if not flow_data:
+        return None
+    for node in flow_data.get("nodes", []):
+        data = node.get("data", {})
+        if data.get("type") != "ConfigurableWebhook":
+            continue
+        template = data.get("node", {}).get("template", {})
+        use_default_response = template.get("use_default_response", {}).get("value", True)
+        if use_default_response:
+            return None
+        return {
+            # Conditional mode (new)
+            "response_rules": template.get("response_rules", {}).get("value"),
+            "default_response": template.get("default_response", {}).get("value"),
+            # Legacy static mode (backward compatible)
+            "status_code": template.get("response_status_code", {}).get("value"),
+            "response_body": template.get("response_body", {}).get("value"),
+        }
+    return None

--- a/src/backend/base/langflow/services/webhook/response_evaluator.py
+++ b/src/backend/base/langflow/services/webhook/response_evaluator.py
@@ -1,0 +1,279 @@
+"""Webhook response evaluation logic for conditional and static responses."""
+
+from __future__ import annotations
+
+import json
+import re
+from http import HTTPStatus
+
+def parse_json_content(value: str, fallback_key: str) -> dict | list:
+    """Parse JSON string, falling back to wrapping primitives."""
+    try:
+        parsed = json.loads(value)
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return {fallback_key: parsed}
+    except json.JSONDecodeError:
+        return {fallback_key: value}
+
+
+def normalize_webhook_response_body(response_body: object | None, raw_body: bytes | str) -> dict | list:
+    """Normalize response body to dict/list format."""
+    raw_value = raw_body.decode() if isinstance(raw_body, bytes) else str(raw_body)
+    if response_body in (None, ""):
+        return parse_json_content(raw_value, "payload")
+    if isinstance(response_body, (dict, list)):
+        return response_body
+    if isinstance(response_body, str):
+        return parse_json_content(response_body, "message")
+    return {"message": str(response_body)}
+
+
+def coerce_webhook_status_code(value: object | None) -> int:
+    """Coerce value to valid HTTP status code."""
+    try:
+        status_code = int(value) if value is not None else int(HTTPStatus.ACCEPTED)
+    except (TypeError, ValueError):
+        return int(HTTPStatus.ACCEPTED)
+    if status_code < 100 or status_code > 599:
+        return int(HTTPStatus.ACCEPTED)
+    return status_code
+
+
+def get_by_dotted_path(payload: object, path: str) -> object | None:
+    """Resolve JSONPath-like dot notation: $.a.b.c
+
+    - Only supports objects/dicts and dot-separated keys.
+    - Returns None if any segment is missing.
+    """
+    if not path:
+        return None
+    p = path.strip()
+    if p.startswith("$"):
+        p = p[1:]
+    if p.startswith("."):
+        p = p[1:]
+    if not p:
+        return payload
+    current: object = payload
+    for seg in p.split("."):
+        if not seg:
+            return None
+        if isinstance(current, dict) and seg in current:
+            current = current[seg]
+        else:
+            return None
+    return current
+
+
+def match_rule_condition(cond: dict, payload: object) -> bool:
+    """Check if condition matches payload.
+
+    Supported condition keys (one rule may include multiple, all must match):
+      - path (required)
+      - equals
+      - not_equals
+      - exists (bool)
+      - in (list)
+      - contains (string or list element)
+      - regex
+      - greater_than
+      - greater_than_or_equal
+      - less_than
+      - less_than_or_equal
+    """
+    path = cond.get("path")
+    if not isinstance(path, str) or not path.strip():
+        return False
+
+    value = get_by_dotted_path(payload, path)
+
+    def to_number(v: object) -> float | None:
+        try:
+            return float(v)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+
+    # exists check
+    if "exists" in cond:
+        exists_expected = bool(cond.get("exists"))
+        exists_actual = value is not None
+        if exists_expected != exists_actual:
+            return False
+
+    # equals check
+    if "equals" in cond:
+        if value != cond.get("equals"):
+            return False
+
+    # not_equals check
+    if "not_equals" in cond:
+        if value == cond.get("not_equals"):
+            return False
+
+    # in check
+    if "in" in cond:
+        haystack = cond.get("in")
+        if not isinstance(haystack, list):
+            return False
+        if value not in haystack:
+            return False
+
+    # contains check
+    if "contains" in cond:
+        needle = cond.get("contains")
+        if isinstance(value, str) and isinstance(needle, str):
+            if needle not in value:
+                return False
+        elif isinstance(value, list):
+            if needle not in value:
+                return False
+        else:
+            return False
+
+    # regex check
+    if "regex" in cond:
+        pattern = cond.get("regex")
+        if not isinstance(value, str) or not isinstance(pattern, str):
+            return False
+        try:
+            if re.search(pattern, value) is None:
+                return False
+        except re.error:
+            return False
+
+    # numeric comparisons
+    for op, cmp_fn in (
+        ("greater_than", lambda a, b: a > b),
+        ("greater_than_or_equal", lambda a, b: a >= b),
+        ("less_than", lambda a, b: a < b),
+        ("less_than_or_equal", lambda a, b: a <= b),
+    ):
+        if op in cond:
+            a = to_number(value)
+            b = to_number(cond.get(op))
+            if a is None or b is None:
+                return False
+            if not cmp_fn(a, b):
+                return False
+
+    return True
+
+
+def render_templates_in_string(s: str, payload: object) -> str:
+    """Replace {{ $.path }} templates with resolved values.
+
+    Minimal templating: replace occurrences of "{{ $.path }}" with resolved value.
+    No loops/conditionals/functions; safe deterministic substitution.
+    """
+    out = s
+    if "{{" not in out:
+        return out
+
+    i = 0
+    while True:
+        start = out.find("{{", i)
+        if start == -1:
+            break
+        end = out.find("}}", start + 2)
+        if end == -1:
+            break
+        expr = out[start + 2 : end].strip()
+        replacement: str = ""
+        if expr.startswith("$"):
+            resolved = get_by_dotted_path(payload, expr)
+            replacement = "" if resolved is None else str(resolved)
+        out = out[:start] + replacement + out[end + 2 :]
+        i = start + len(replacement)
+    return out
+
+
+def render_templates(obj: object, payload: object) -> object:
+    """Recursively render templates in objects."""
+    if isinstance(obj, str):
+        return render_templates_in_string(obj, payload)
+    if isinstance(obj, list):
+        return [render_templates(item, payload) for item in obj]
+    if isinstance(obj, dict):
+        return {k: render_templates(v, payload) for k, v in obj.items()}
+    return obj
+
+
+def parse_json_maybe(raw: object) -> object:
+    """Parse JSON if string, otherwise return as-is."""
+    if raw is None:
+        return None
+    if isinstance(raw, (dict, list)):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+    return raw
+
+
+def evaluate_configurable_webhook_response(
+    response_config: dict,
+    raw_body: bytes | str,
+) -> tuple[int, dict | list]:
+    """Evaluate webhook response based on configuration.
+
+    Priority:
+      1) response_rules + default_response (conditional mode)
+      2) legacy response_status_code/response_body (static mode)
+      3) echo payload / accepted
+
+    Args:
+        response_config: Configuration dict with response_rules, default_response,
+                        status_code, and response_body keys
+        raw_body: Raw request body as bytes or string
+
+    Returns:
+        Tuple of (status_code, response_body)
+    """
+    raw_text = raw_body.decode() if isinstance(raw_body, bytes) else str(raw_body)
+    payload_obj = parse_json_maybe(raw_text)
+
+    # Prepare payload for matching
+    match_payload: object
+    if isinstance(payload_obj, (dict, list)):
+        match_payload = payload_obj
+    else:
+        match_payload = {"payload": payload_obj}
+
+    # Try conditional mode first
+    rules_raw = parse_json_maybe(response_config.get("response_rules"))
+    default_raw = parse_json_maybe(response_config.get("default_response"))
+
+    if isinstance(rules_raw, list):
+        # Evaluate rules
+        for rule in rules_raw:
+            if not isinstance(rule, dict):
+                continue
+            cond = rule.get("when")
+            resp = rule.get("response")
+            if not isinstance(cond, dict) or not isinstance(resp, dict):
+                continue
+            if match_rule_condition(cond, match_payload):
+                status_code = coerce_webhook_status_code(resp.get("status_code"))
+                body = resp.get("body")
+                body_obj = parse_json_maybe(body)
+                rendered = render_templates(body_obj, match_payload)
+                if isinstance(rendered, (dict, list)):
+                    return status_code, rendered
+                return status_code, {"message": str(rendered)}
+
+        # No rule matched, use default_response
+        if isinstance(default_raw, dict):
+            status_code = coerce_webhook_status_code(default_raw.get("status_code"))
+            body_obj = parse_json_maybe(default_raw.get("body"))
+            rendered = render_templates(body_obj, match_payload)
+            if isinstance(rendered, (dict, list)):
+                return status_code, rendered
+            return status_code, {"message": str(rendered)}
+
+    # Legacy static mode
+    status_code = coerce_webhook_status_code(response_config.get("status_code"))
+    body = normalize_webhook_response_body(response_config.get("response_body"), raw_body)
+    return status_code, body

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
@@ -22,7 +22,9 @@ export function StrRenderComponent({
   const isMultiline = templateData.multiline;
   const copyField = templateData.copy_field;
   const hasOptions = !!templateData.options;
-  const isWebhook = nodeInformationMetadata?.nodeType === "webhook";
+  const isWebhook = ["webhook", "configurablewebhook"].includes(
+    nodeInformationMetadata?.nodeType?.toLowerCase() ?? "",
+  );
 
   if (noOptions) {
     if (isMultiline) {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -79,7 +79,10 @@ export default function TextAreaComponent({
   const [cursor, setCursor] = useState<number | null>(null);
 
   const isWebhook = useMemo(
-    () => nodeInformationMetadata?.nodeType === "webhook",
+    () =>
+      ["webhook", "configurablewebhook"].includes(
+        nodeInformationMetadata?.nodeType?.toLowerCase() ?? "",
+      ),
     [nodeInformationMetadata?.nodeType],
   );
 

--- a/src/lfx/src/lfx/components/data/__init__.py
+++ b/src/lfx/src/lfx/components/data/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 _dynamic_imports = {
     "APIRequestComponent": "api_request",
     "CSVToDataComponent": "csv_to_data",
+    "ConfigurableWebhookComponent": "configurable_webhook",
     "DirectoryComponent": "directory",
     "FileComponent": "file",
     "JSONToDataComponent": "json_to_data",
@@ -34,6 +35,7 @@ _dynamic_imports = {
 __all__ = [
     "APIRequestComponent",
     "CSVToDataComponent",
+    "ConfigurableWebhookComponent",
     "DirectoryComponent",
     "FileComponent",
     "JSONToDataComponent",

--- a/src/lfx/src/lfx/components/data/configurable_webhook.py
+++ b/src/lfx/src/lfx/components/data/configurable_webhook.py
@@ -1,0 +1,188 @@
+"""Configurable webhook component with conditional response support."""
+
+import json
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import BoolInput, IntInput, MultilineInput, Output
+from lfx.schema.data import Data
+
+
+def _get_default_rules() -> str:
+    """Get default example rules."""
+    return '''[
+  {
+    "when": { "path": "$.event", "equals": "order.created" },
+    "response": {
+      "status_code": 201,
+      "body": { "status": "created", "order_id": "{{ $.id }}" }
+    }
+  },
+  {
+    "when": { "path": "$.customer_id", "exists": true },
+    "response": {
+      "status_code": 200,
+      "body": { "status": "customer_present", "customer_id": "{{ $.customer_id }}" }
+    }
+  },
+  {
+    "when": { "path": "$.event", "in": ["order.updated", "order.cancelled"] },
+    "response": {
+      "status_code": 200,
+      "body": { "status": "order_changed", "event": "{{ $.event }}" }
+    }
+  },
+  {
+    "when": { "path": "$.amount", "greater_than": 1000 },
+    "response": {
+      "status_code": 402,
+      "body": { "status": "too_large", "amount": "{{ $.amount }}" }
+    }
+  }
+]'''
+
+
+def _get_rules_info() -> str:
+    """Get info text for rules field."""
+    return (
+        "JSON array of conditional rules. First match wins.\n"
+        'Condition supports: {"path":"$.a.b","equals":...,"not_equals":...,"exists":true,'
+        '"in":[...],"contains":"...","regex":"...","greater_than":...,'
+        '"greater_than_or_equal":...,"less_than":...,"less_than_or_equal":...}.\n'
+        'Response: {"status_code": 200-599, "body": <json with {{ $.path }} templates>}.\n'
+        "Leave empty to disable conditional mode."
+    )
+
+
+class ConfigurableWebhookComponent(Component):
+    display_name = "Configurable Webhook"
+    description = "Webhook input with configurable response options (including conditional responses)."
+    documentation: str = "https://docs.langflow.org/components-data#webhook"
+    name = "ConfigurableWebhook"
+    icon = "webhook"
+
+    inputs = [
+        MultilineInput(
+            name="data",
+            display_name="Payload",
+            info="Receives a payload from external systems via HTTP POST.",
+            advanced=True,
+        ),
+        MultilineInput(
+            name="curl",
+            display_name="cURL",
+            value="CURL_WEBHOOK",
+            advanced=True,
+            input_types=[],
+        ),
+        MultilineInput(
+            name="endpoint",
+            display_name="Endpoint",
+            value="BACKEND_URL",
+            advanced=False,
+            copy_field=True,
+            input_types=[],
+        ),
+        BoolInput(
+            name="use_default_response",
+            display_name="Use Default Response",
+            value=True,
+            info="Return the default 202 response when enabled.",
+            advanced=True,
+        ),
+        # Conditional mode
+        MultilineInput(
+            name="response_rules",
+            display_name="Response Rules (JSON)",
+            value=_get_default_rules(),
+            info=_get_rules_info(),
+            advanced=True,
+        ),
+        MultilineInput(
+            name="default_response",
+            display_name="Default Response (JSON)",
+            value='{\n  "status_code": 202,\n  "body": { "status": "accepted" }\n}',
+            info="Fallback response when no rules match (conditional mode).",
+            advanced=True,
+        ),
+        # Legacy static mode
+        IntInput(
+            name="response_status_code",
+            display_name="Response Status Code (Legacy)",
+            value=202,
+            info="(Legacy) HTTP status code for static responses.",
+            advanced=True,
+        ),
+        MultilineInput(
+            name="response_body",
+            display_name="Response Body (Legacy)",
+            value='{"message": "Task started in the background", "status": "in progress"}',
+            info="(Legacy) JSON or text to return. Leave blank to echo payload.",
+            advanced=True,
+        ),
+        BoolInput(
+            name="use_response_body_as_output",
+            display_name="Use Response as Output",
+            value=False,
+            info="Use configured response body as component output instead of incoming payload.",
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Data", name="output_data", method="build_data"),
+    ]
+
+    def build_data(self) -> Data:
+        """Build data output from webhook payload."""
+        if not self.data:
+            self.status = "No data provided."
+            return Data(data={})
+
+        # Parse payload
+        payload_value = self.data.replace('"\n"', '"\\n"')
+        try:
+            payload_obj = json.loads(payload_value or "{}")
+        except json.JSONDecodeError:
+            payload_obj = {"payload": payload_value}
+
+        # Import evaluation logic
+        from langflow.services.webhook.response_evaluator import (
+            evaluate_configurable_webhook_response,
+        )
+
+        # Get response configuration
+        response_config = {
+            "response_rules": self.response_rules,
+            "default_response": self.default_response,
+            "status_code": self.response_status_code,
+            "response_body": self.response_body,
+        }
+
+        # Evaluate response
+        try:
+            status_code, selected_body = evaluate_configurable_webhook_response(
+                response_config,
+                json.dumps(payload_obj) if isinstance(payload_obj, (dict, list)) else str(payload_obj),
+            )
+        except Exception as exc:
+            self.status = f"Error evaluating response: {exc}"
+            return Data(data=payload_obj if isinstance(payload_obj, dict) else {"payload": payload_obj})
+
+        # Return selected response or payload
+        if self.use_response_body_as_output:
+            if isinstance(selected_body, dict):
+                out_data = selected_body
+            elif isinstance(selected_body, list):
+                out_data = {"payload": selected_body}
+            else:
+                out_data = {"message": str(selected_body)}
+            self.status = f"Selected response as output.\nStatus Code: {status_code}"
+            return Data(data=out_data)
+
+        # Default: return payload
+        if isinstance(payload_obj, dict):
+            self.status = "Parsed payload."
+            return Data(data=payload_obj)
+
+        self.status = "Parsed payload."
+        return Data(data={"payload": payload_obj})


### PR DESCRIPTION
### Motivation
- Allow flows to define immediate, configurable HTTP responses for webhook-triggered runs, including conditional rules and backward-compatible static responses.
- Provide a safe evaluation path so webhook endpoints can return dynamic status codes and bodies without blocking background flow execution.

### Description
- Evaluate and return a configured webhook response in the webhook endpoint by adding `get_configurable_webhook_response` usage and returning a `JSONResponse` when a configured payload is available in `webhook_run_flow` (`src/backend/base/langflow/api/v1/endpoints.py`).
- Add `get_configurable_webhook_response` to extract response settings from flow data (`src/backend/base/langflow/services/database/models/flow/utils.py`).
- Implement `evaluate_configurable_webhook_response` and supporting helpers (parsing, path lookup, condition matching, template rendering, status coercion, legacy fallback) in a new module `src/backend/base/langflow/services/webhook/response_evaluator.py` to support conditional rules, default responses, and legacy static responses.
- Add a new `ConfigurableWebhookComponent` so flows can configure conditional responses via the UI, and export it in the LFX data components registry (`src/lfx/src/lfx/components/data/configurable_webhook.py` and `src/lfx/src/lfx/components/data/__init__.py`).
- Update frontend webhook detection so UI components treat `configurablewebhook` like the existing `webhook` node type (`src/frontend/.../strRenderComponent/index.tsx` and `textAreaComponent/index.tsx`).

### Testing
- No automated tests were executed as part of this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976e63e76508326b0410056d8cb474e)