### PR TITLE
Persist vertex builds and fix webhook polling initialization

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
@@ -20,6 +20,7 @@ export default function WebhookFieldComponent({
   const [userId, setUserId] = useState("");
   const { mutate: getBuildsMutation } = useGetBuildsMutation();
   const hasInitialized = useRef(false);
+  const lastFlowIdRef = useRef<string | null>(null);
   const modalProps = getModalPropsApiKey();
 
   const isBackendUrl = nodeInformationMetadata?.variableName === "endpoint";
@@ -30,17 +31,29 @@ export default function WebhookFieldComponent({
     (ENABLE_DATASTAX_LANGFLOW && !editNode);
 
   useEffect(() => {
-    const getBuilds =
-      (!editNode && isBackendUrl && !hasInitialized.current) ||
-      (ENABLE_DATASTAX_LANGFLOW && !editNode);
+    const flowId = nodeInformationMetadata?.flowId;
+    const shouldPoll =
+      (!editNode && isBackendUrl) || (ENABLE_DATASTAX_LANGFLOW && !editNode);
 
-    if (getBuilds) {
-      hasInitialized.current = true;
-      getBuildsMutation({
-        flowId: nodeInformationMetadata?.flowId!,
-      });
+    if (!shouldPoll || !flowId) {
+      return;
     }
-  }, []);
+
+    if (hasInitialized.current && lastFlowIdRef.current === flowId) {
+      return;
+    }
+
+    hasInitialized.current = true;
+    lastFlowIdRef.current = flowId;
+    getBuildsMutation({
+      flowId,
+    });
+  }, [
+    editNode,
+    getBuildsMutation,
+    isBackendUrl,
+    nodeInformationMetadata?.flowId,
+  ]);
 
   useEffect(() => {
     if (userData) {

--- a/src/lfx/src/lfx/graph/utils.py
+++ b/src/lfx/src/lfx/graph/utils.py
@@ -155,6 +155,8 @@ async def log_vertex_build(
     if not settings_service or not getattr(settings_service.settings, "vertex_builds_storage_enabled", False):
         return
 
+    from langflow.services.deps import get_db_service, session_scope
+
     db_service = get_db_service()
     if db_service is None:
         logger.debug("Database service not available, skipping vertex build logging")
@@ -169,8 +171,6 @@ async def log_vertex_build(
 
     from langflow.services.database.models.vertex_builds.crud import log_vertex_build as persist_vertex_build
     from langflow.services.database.models.vertex_builds.model import VertexBuildBase
-    from lfx.services.deps import session_scope
-
     try:
         vertex_build = VertexBuildBase(
             id=vertex_id,

--- a/src/lfx/src/lfx/graph/utils.py
+++ b/src/lfx/src/lfx/graph/utils.py
@@ -151,25 +151,42 @@ async def log_vertex_build(
 
     This is a lightweight implementation that only logs if database service is available.
     """
-    try:
-        settings_service = get_settings_service()
-        if not settings_service or not getattr(settings_service.settings, "vertex_builds_storage_enabled", False):
-            return
+    settings_service = get_settings_service()
+    if not settings_service or not getattr(settings_service.settings, "vertex_builds_storage_enabled", False):
+        return
 
-        db_service = get_db_service()
-        if db_service is None:
-            logger.debug("Database service not available, skipping vertex build logging")
-            return
+    db_service = get_db_service()
+    if db_service is None:
+        logger.debug("Database service not available, skipping vertex build logging")
+        return
 
+    if isinstance(flow_id, str):
         try:
-            if isinstance(flow_id, str):
-                flow_id = UUID(flow_id)
+            flow_id = UUID(flow_id)
         except ValueError:
             logger.debug(f"Invalid flow_id passed to log_vertex_build: {flow_id!r}")
             return
 
-        # Log basic vertex build info - concrete implementation should be in langflow
-        logger.debug(f"Vertex build logged: vertex={vertex_id}, flow={flow_id}, valid={valid}")
+    from langflow.services.database.models.vertex_builds.crud import log_vertex_build as persist_vertex_build
+    from langflow.services.database.models.vertex_builds.model import VertexBuildBase
+    from lfx.services.deps import session_scope
+
+    try:
+        vertex_build = VertexBuildBase(
+            id=vertex_id,
+            flow_id=flow_id,
+            valid=valid,
+            params=params,
+            data=data,
+            artifacts=artifacts,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("Error creating vertex build payload")
+        return
+
+    try:
+        async with session_scope() as session:
+            await persist_vertex_build(session, vertex_build)
     except Exception:  # noqa: BLE001
         logger.debug("Error logging vertex build")
 


### PR DESCRIPTION
### Motivation
- Webhook runs were not showing data in the UI because `/monitor/builds` polling returned no persisted vertex builds, so the Data indicator never turned on. 
- A prior frontend polling fix made `useEffect` depend on `flowId` but the backend `log_vertex_build` implementation was a no-op and therefore produced no records to be polled. 
- The change also addresses the observed warning `Graph has vertices but no edges` as a diagnostic note (the warning itself does not block persistence). 

### Description
- Persist vertex builds during graph execution by updating `lfx/graph/utils.py` so `log_vertex_build` now creates a `VertexBuildBase` payload and persists it through the database API using `session_scope` and `langflow.services.database.models.vertex_builds.crud.log_vertex_build`. 
- Harden `log_vertex_build` to early-return when `vertex_builds_storage_enabled` is disabled or DB service is not available and to safely convert `flow_id` to a `UUID` before persisting. 
- Update frontend polling in `src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx` to track `flowId` with `lastFlowIdRef`, compute `shouldPoll`, and make the polling `useEffect` depend on `nodeInformationMetadata?.flowId`, `editNode`, and `isBackendUrl` to trigger `getBuildsMutation` when `flowId` becomes available while avoiding duplicate polls. 
- Files changed: `src/lfx/src/lfx/graph/utils.py` and `src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7be2d2ec832695cdc0cef8ba88d6)