### PR TITLE
Log webhook payloads to vertex builds and add webhook debug logs (backend + frontend)

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
@@ -31,6 +32,7 @@ from langflow.api.v1.schemas import (
     ConfigResponse,
     CustomComponentRequest,
     CustomComponentResponse,
+    ResultDataResponse,
     RunResponse,
     SimplifiedAPIRequest,
     TaskStatusResponse,
@@ -48,8 +50,10 @@ from langflow.services.auth.utils import api_key_security, get_current_active_us
 from langflow.services.cache.utils import save_uploaded_file
 from langflow.services.database.models.flow.model import Flow, FlowRead
 from langflow.services.database.models.flow.utils import get_all_webhook_components_in_flow
+from langflow.services.database.models.vertex_builds.crud import log_vertex_build
+from langflow.services.database.models.vertex_builds.model import VertexBuildBase
 from langflow.services.database.models.user.model import User, UserRead
-from langflow.services.deps import get_session_service, get_settings_service, get_telemetry_service
+from langflow.services.deps import get_session_service, get_settings_service, get_telemetry_service, session_scope
 from langflow.services.telemetry.schema import RunPayload
 from langflow.utils.compression import compress_response
 from langflow.utils.version import get_version_info
@@ -464,10 +468,17 @@ async def webhook_run_flow(
     telemetry_service = get_telemetry_service()
     start_time = time.perf_counter()
     await logger.adebug("Received webhook request")
+    logger.info(
+        "[Webhook] Incoming request: flow_id_or_name=%s, flow_id=%s, endpoint_name=%s",
+        flow_id_or_name,
+        getattr(flow, "id", None),
+        getattr(flow, "endpoint_name", None),
+    )
     error_msg = ""
 
     # Get the appropriate user for webhook execution based on auth settings
     webhook_user = await get_webhook_user(flow_id_or_name, request)
+    logger.info("[Webhook] Resolved webhook_user=%s", getattr(webhook_user, "id", None))
 
     try:
         try:
@@ -479,20 +490,55 @@ async def webhook_run_flow(
         if not data:
             error_msg = "Request body is empty. You should provide a JSON payload containing the flow ID."
             raise HTTPException(status_code=400, detail=error_msg)
+        logger.info("[Webhook] Raw request body length=%s bytes", len(data))
 
         try:
             # get all webhook components in the flow
             webhook_components = get_all_webhook_components_in_flow(flow.data)
             tweaks = {}
+            payload_text = data.decode() if isinstance(data, bytes) else data
+            try:
+                payload_message = json.loads(payload_text) if isinstance(payload_text, str) else payload_text
+            except json.JSONDecodeError:
+                payload_message = payload_text
 
-            for component in webhook_components:
-                tweaks[component["id"]] = {"data": data.decode() if isinstance(data, bytes) else data}
+            async with session_scope() as session:
+                for component in webhook_components:
+                    tweaks[component["id"]] = {"data": data.decode() if isinstance(data, bytes) else data}
+                    output_name = "output_data"
+                    component_outputs = component.get("data", {}).get("node", {}).get("outputs", [])
+                    if component_outputs:
+                        output_name = component_outputs[0].get("name", output_name)
+                    result_data = ResultDataResponse(
+                        outputs={output_name: {"message": payload_message, "type": "data"}},
+                        message=payload_message,
+                    )
+                    await log_vertex_build(
+                        session,
+                        VertexBuildBase(
+                            id=component["id"],
+                            flow_id=flow.id,
+                            valid=True,
+                            params={},
+                            data=result_data.model_dump(),
+                            artifacts={},
+                        ),
+                    )
+            logger.info(
+                "[Webhook] Prepared tweaks for webhook components count=%s ids=%s",
+                len(webhook_components),
+                [component.get("id") for component in webhook_components],
+            )
             input_request = SimplifiedAPIRequest(
                 input_value="",
                 input_type="chat",
                 output_type="chat",
                 tweaks=tweaks,
                 session_id=None,
+            )
+            logger.info(
+                "[Webhook] Enqueued background task for flow_id=%s",
+                getattr(flow, "id", None),
             )
 
             await logger.adebug("Starting background task")

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -519,7 +519,7 @@ async def webhook_run_flow(
                             id=component["id"],
                             flow_id=flow.id,
                             valid=True,
-                            params={},
+                            params="",
                             data=result_data.model_dump(),
                             artifacts={},
                         ),

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -282,6 +282,11 @@ async def get_webhook_user(flow_id: str, request: Request) -> UserRead:
     from langflow.helpers.user import get_user_by_flow_id_or_endpoint_name
 
     settings_service = get_settings_service()
+    logger.info(
+        "[WebhookAuth] Resolving webhook user. flow_id_or_name=%s webhook_auth_enabled=%s",
+        flow_id,
+        settings_service.auth_settings.WEBHOOK_AUTH_ENABLE,
+    )
 
     if not settings_service.auth_settings.WEBHOOK_AUTH_ENABLE:
         # When webhook auth is disabled, run webhook as the flow owner without requiring API key
@@ -289,6 +294,7 @@ async def get_webhook_user(flow_id: str, request: Request) -> UserRead:
             flow_owner = await get_user_by_flow_id_or_endpoint_name(flow_id)
             if flow_owner is None:
                 raise HTTPException(status_code=404, detail="Flow not found")
+            logger.info("[WebhookAuth] Using flow owner for webhook. user_id=%s", flow_owner.id)
             return flow_owner  # noqa: TRY300
         except HTTPException:
             raise
@@ -298,6 +304,11 @@ async def get_webhook_user(flow_id: str, request: Request) -> UserRead:
     # When webhook auth is enabled, require API key authentication
     api_key_header_val = request.headers.get("x-api-key")
     api_key_query_val = request.query_params.get("x-api-key")
+    logger.info(
+        "[WebhookAuth] API key presence header=%s query=%s",
+        bool(api_key_header_val),
+        bool(api_key_query_val),
+    )
 
     # Check if API key is provided
     if not api_key_header_val and not api_key_query_val:

--- a/src/frontend/src/components/core/parameterRenderComponent/components/copyFieldAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/copyFieldAreaComponent/index.tsx
@@ -76,6 +76,11 @@ export default function CopyFieldAreaComponent({
     }
     return value;
   }, [value, endpointName]);
+  console.log("[Webhook][CopyFieldAreaComponent] render", {
+    value,
+    endpointName,
+    valueToRender,
+  });
 
   const getInputClassName = () => {
     return cn(
@@ -96,6 +101,9 @@ export default function CopyFieldAreaComponent({
 
     setSuccessData({
       title: "Endpoint URL copied",
+    });
+    console.log("[Webhook][CopyFieldAreaComponent] copied", {
+      valueToRender,
     });
 
     event?.stopPropagation();

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
@@ -23,6 +23,15 @@ export function StrRenderComponent({
   const copyField = templateData.copy_field;
   const hasOptions = !!templateData.options;
   const isWebhook = nodeInformationMetadata?.nodeType === "webhook";
+  console.log("[Webhook][StrRenderComponent] render", {
+    nodeType: nodeInformationMetadata?.nodeType,
+    isWebhook,
+    id,
+    name,
+    isMultiline,
+    copyField,
+    hasOptions,
+  });
 
   if (noOptions) {
     if (isMultiline) {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -90,6 +90,12 @@ export default function TextAreaComponent({
 
   useEffect(() => {
     if (isWebhook && value === WEBHOOK_VALUE) {
+      console.log("[Webhook][TextAreaComponent] generating webhook cURL", {
+        flowId: nodeInformationMetadata?.flowId,
+        flowName: nodeInformationMetadata?.flowName,
+        webhookAuthEnable,
+        format: "singleline",
+      });
       const curlWebhookCode = getCurlWebhookCode({
         flowId: nodeInformationMetadata?.flowId!,
         webhookAuthEnable,
@@ -133,6 +139,12 @@ export default function TextAreaComponent({
 
   const changeWebhookFormat = (format: "multiline" | "singleline") => {
     if (isWebhook) {
+      console.log("[Webhook][TextAreaComponent] change cURL format", {
+        format,
+        flowId: nodeInformationMetadata?.flowId,
+        flowName: nodeInformationMetadata?.flowName,
+        webhookAuthEnable,
+      });
       const curlWebhookCode = getCurlWebhookCode({
         flowId: nodeInformationMetadata?.flowId!,
         webhookAuthEnable,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
@@ -30,11 +30,22 @@ export default function WebhookFieldComponent({
     (ENABLE_DATASTAX_LANGFLOW && !editNode);
 
   useEffect(() => {
+    console.log("[Webhook][WebhookFieldComponent] mount", {
+      flowId: nodeInformationMetadata?.flowId,
+      variableName: nodeInformationMetadata?.variableName,
+      isBackendUrl,
+      isCurlWebhook,
+      showGenerateToken,
+      editNode,
+    });
     const getBuilds =
       (!editNode && isBackendUrl && !hasInitialized.current) ||
       (ENABLE_DATASTAX_LANGFLOW && !editNode);
 
     if (getBuilds) {
+      console.log("[Webhook][WebhookFieldComponent] triggering builds polling", {
+        flowId: nodeInformationMetadata?.flowId,
+      });
       hasInitialized.current = true;
       getBuildsMutation({
         flowId: nodeInformationMetadata?.flowId!,
@@ -45,6 +56,9 @@ export default function WebhookFieldComponent({
   useEffect(() => {
     if (userData) {
       setUserId(userData.id);
+      console.log("[Webhook][WebhookFieldComponent] user set", {
+        userId: userData.id,
+      });
     }
   }, [userData]);
 

--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -31,6 +31,12 @@ export function getCurlWebhookCode({
     endpointName || flowId
   }`;
   const authHeader = webhookAuthEnable ? `-H 'x-api-key: <your api key>'` : "";
+  console.log("[Webhook][getCurlWebhookCode] build", {
+    baseUrl,
+    webhookAuthEnable,
+    format,
+    hasEndpointName: Boolean(endpointName),
+  });
 
   if (format === "singleline") {
     return `curl -X POST "${baseUrl}" -H 'Content-Type: application/json' ${authHeader} -d '{"any": "data"}'`.trim();


### PR DESCRIPTION
### Motivation
- Fix the Webhook "Data" indicator not turning on after receiving webhook requests by ensuring webhook payloads are recorded in vertex build logs that the UI polls to decide indicator state.
- Make webhook request handling and auth decisions easier to debug by surfacing informative runtime logs on both backend and frontend.

### Description
- Backend: parse webhook request payloads, build a `ResultDataResponse` containing the payload under the webhook component output (default `output_data`), and persist it with `log_vertex_build` so polling `/monitor/builds` will expose the new output message for the UI; this also adds `json` imports and uses `session_scope` for DB work and new `logger.info` calls in the webhook path (`webhook_run_flow`).
- Auth: add `logger.info` statements in `get_webhook_user` to log webhook auth configuration and whether an API key was provided in header/query for easier troubleshooting.
- Frontend: add `console.log` debug statements in `StrRenderComponent`, `CopyFieldAreaComponent`, `TextAreaComponent`, `WebhookFieldComponent`, and `getCurlWebhookCode` to report render/mount lifecycle, generated cURL code, copy actions, user info, and build-polling triggers.
- Behavior preservation: the change only logs and persists a vertex build for webhook payloads and leaves the existing background flow run and tweaks behavior intact so webhook execution is unchanged except for the new persistence and logs.

### Testing
- No automated tests were executed for these changes because they are logging and persistence additions; manual verification steps are provided instead and recommended: send a webhook POST, wait for the next polling refresh (or reload the flow page), and confirm the Webhook node's Data indicator turns on because a vertex build now contains `outputs.<output_name>.message`.
- No test failures were observed because no test suite was run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c96c124808326ba4be449ef3bdae7)