### PR TITLE
Add Generate API Key button and inject x-api-key into webhook cURL snippets

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -8,7 +8,11 @@ import { cn } from "../../../../../utils/utils";
 import IconComponent from "../../../../common/genericIconComponent";
 import { Input } from "../../../../ui/input";
 import WebhookCurlApiKeyButton from "../webhookFieldComponent/components/webhook-curl-api-key-button";
-import { ensureCurlHasApiKeyHeader } from "../webhookFieldComponent/utils/webhook-curl-utils";
+import {
+  ensureCurlHasApiKeyHeader,
+  getApiKeyFromCurl,
+  WEBHOOK_API_KEY_PLACEHOLDER,
+} from "../webhookFieldComponent/utils/webhook-curl-utils";
 import { getPlaceholder } from "../../helpers/get-placeholder-disabled";
 import type { InputProps, TextAreaComponentType } from "../../types";
 import { getIconName } from "../inputComponent/components/helpers/get-icon-name";
@@ -137,6 +141,7 @@ export default function TextAreaComponent({
 
   const changeWebhookFormat = (format: "multiline" | "singleline") => {
     if (isWebhook) {
+      const existingApiKey = getApiKeyFromCurl(value ?? "");
       const curlWebhookCode = getCurlWebhookCode({
         flowId: nodeInformationMetadata?.flowId!,
         webhookAuthEnable,
@@ -144,7 +149,10 @@ export default function TextAreaComponent({
         format,
       });
       handleOnNewValue({
-        value: ensureCurlHasApiKeyHeader(curlWebhookCode),
+        value: ensureCurlHasApiKeyHeader(
+          curlWebhookCode,
+          existingApiKey ?? WEBHOOK_API_KEY_PLACEHOLDER,
+        ),
       });
     }
   };
@@ -157,6 +165,8 @@ export default function TextAreaComponent({
     const updatedCurl = ensureCurlHasApiKeyHeader(value ?? "", apiKeyValue);
     handleOnNewValue({ value: updatedCurl });
   };
+
+  const hasGeneratedApiKey = !!getApiKeyFromCurl(value ?? "");
 
   const renderIcon = () => (
     <div>
@@ -230,6 +240,7 @@ export default function TextAreaComponent({
             <WebhookCurlApiKeyButton
               onApiKeyGenerated={handleApiKeyGenerated}
               disabled={disabled}
+              hasGeneratedApiKey={hasGeneratedApiKey}
             />
           ) : undefined
         }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -7,6 +7,7 @@ import { useUtilityStore } from "@/stores/utilityStore";
 import { cn } from "../../../../../utils/utils";
 import IconComponent from "../../../../common/genericIconComponent";
 import { Input } from "../../../../ui/input";
+import { ensureCurlHasApiKeyHeader } from "../webhookFieldComponent/utils/webhook-curl-utils";
 import { getPlaceholder } from "../../helpers/get-placeholder-disabled";
 import type { InputProps, TextAreaComponentType } from "../../types";
 import { getIconName } from "../inputComponent/components/helpers/get-icon-name";
@@ -96,7 +97,9 @@ export default function TextAreaComponent({
         flowName: nodeInformationMetadata?.flowName!,
         format: "singleline",
       });
-      handleOnNewValue({ value: curlWebhookCode });
+      handleOnNewValue({
+        value: ensureCurlHasApiKeyHeader(curlWebhookCode),
+      });
     } else if (value === MCP_SSE_VALUE) {
       const mcpSSEUrl = `${URL_MCP_SSE}`;
       handleOnNewValue({ value: mcpSSEUrl });
@@ -139,7 +142,9 @@ export default function TextAreaComponent({
         flowName: nodeInformationMetadata?.flowName!,
         format,
       });
-      handleOnNewValue({ value: curlWebhookCode });
+      handleOnNewValue({
+        value: ensureCurlHasApiKeyHeader(curlWebhookCode),
+      });
     }
   };
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -7,6 +7,7 @@ import { useUtilityStore } from "@/stores/utilityStore";
 import { cn } from "../../../../../utils/utils";
 import IconComponent from "../../../../common/genericIconComponent";
 import { Input } from "../../../../ui/input";
+import WebhookCurlApiKeyButton from "../webhookFieldComponent/components/webhook-curl-api-key-button";
 import { ensureCurlHasApiKeyHeader } from "../webhookFieldComponent/utils/webhook-curl-utils";
 import { getPlaceholder } from "../../helpers/get-placeholder-disabled";
 import type { InputProps, TextAreaComponentType } from "../../types";
@@ -148,6 +149,15 @@ export default function TextAreaComponent({
     }
   };
 
+  const handleApiKeyGenerated = (apiKeyValue: string) => {
+    if (!isWebhook) {
+      return;
+    }
+
+    const updatedCurl = ensureCurlHasApiKeyHeader(value ?? "", apiKeyValue);
+    handleOnNewValue({ value: updatedCurl });
+  };
+
   const renderIcon = () => (
     <div>
       {!disabled && !isFocused && (
@@ -215,6 +225,14 @@ export default function TextAreaComponent({
         setValue={(newValue) => handleOnNewValue({ value: newValue })}
         disabled={disabled}
         onCloseModal={() => changeWebhookFormat("singleline")}
+        footerSlot={
+          isWebhook ? (
+            <WebhookCurlApiKeyButton
+              onApiKeyGenerated={handleApiKeyGenerated}
+              disabled={disabled}
+            />
+          ) : undefined
+        }
       >
         <div
           onClick={() => changeWebhookFormat("multiline")}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/components/webhook-curl-api-key-button.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/components/webhook-curl-api-key-button.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
+import { useGenerateToken } from "@/customization/hooks/use-custom-generate-token";
+import { createApiKey } from "@/controllers/API";
+
+type WebhookCurlApiKeyButtonProps = {
+  onApiKeyGenerated: (apiKey: string) => void;
+  disabled?: boolean;
+};
+
+const DEFAULT_API_KEY_NAME = "Webhook curl key";
+
+export default function WebhookCurlApiKeyButton({
+  onApiKeyGenerated,
+  disabled,
+}: WebhookCurlApiKeyButtonProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const generateToken = useGenerateToken();
+
+  const handleGenerateKey = async () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      let apiKeyValue = "";
+
+      if (ENABLE_DATASTAX_LANGFLOW) {
+        const response = await generateToken();
+        apiKeyValue = response?.token ?? response ?? "";
+      } else {
+        const response = await createApiKey(DEFAULT_API_KEY_NAME);
+        apiKeyValue = response?.api_key ?? "";
+      }
+
+      if (apiKeyValue) {
+        onApiKeyGenerated(apiKeyValue);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      onClick={handleGenerateKey}
+      disabled={disabled || isLoading}
+    >
+      {isLoading ? "Generating..." : "Generate API Key"}
+    </Button>
+  );
+}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/components/webhook-curl-api-key-button.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/components/webhook-curl-api-key-button.tsx
@@ -7,6 +7,7 @@ import { createApiKey } from "@/controllers/API";
 type WebhookCurlApiKeyButtonProps = {
   onApiKeyGenerated: (apiKey: string) => void;
   disabled?: boolean;
+  hasGeneratedApiKey?: boolean;
 };
 
 const DEFAULT_API_KEY_NAME = "Webhook curl key";
@@ -14,12 +15,13 @@ const DEFAULT_API_KEY_NAME = "Webhook curl key";
 export default function WebhookCurlApiKeyButton({
   onApiKeyGenerated,
   disabled,
+  hasGeneratedApiKey = false,
 }: WebhookCurlApiKeyButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
   const generateToken = useGenerateToken();
 
   const handleGenerateKey = async () => {
-    if (isLoading) {
+    if (isLoading || hasGeneratedApiKey) {
       return;
     }
 
@@ -48,9 +50,13 @@ export default function WebhookCurlApiKeyButton({
       type="button"
       variant="secondary"
       onClick={handleGenerateKey}
-      disabled={disabled || isLoading}
+      disabled={disabled || isLoading || hasGeneratedApiKey}
     >
-      {isLoading ? "Generating..." : "Generate API Key"}
+      {hasGeneratedApiKey
+        ? "API key is generated"
+        : isLoading
+          ? "Generating..."
+          : "Generate API Key"}
     </Button>
   );
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { AuthContext } from "@/contexts/authContext";
 import { useGetBuildsMutation } from "@/controllers/API/queries/_builds/use-get-builds-polling-mutation";
 import SecretKeyModalButton from "@/customization/components/custom-secret-key-modal-button";
@@ -7,8 +7,6 @@ import { getModalPropsApiKey } from "@/customization/utils/get-modal-props";
 import type { InputProps, TextAreaComponentType } from "../../types";
 import CopyFieldAreaComponent from "../copyFieldAreaComponent";
 import TextAreaComponent from "../textAreaComponent";
-import WebhookCurlApiKeyButton from "./components/webhook-curl-api-key-button";
-import { ensureCurlHasApiKeyHeader } from "./utils/webhook-curl-utils";
 
 export default function WebhookFieldComponent({
   value,
@@ -30,21 +28,6 @@ export default function WebhookFieldComponent({
   const showGenerateToken =
     (isBackendUrl && !editNode && !isAuth) ||
     (ENABLE_DATASTAX_LANGFLOW && !editNode);
-  const handleApiKeyGenerated = useCallback(
-    (apiKeyValue: string) => {
-      if (!isCurlWebhook) {
-        return;
-      }
-
-      const updatedCurl = ensureCurlHasApiKeyHeader(
-        value ?? "",
-        apiKeyValue,
-      );
-      handleOnNewValue({ value: updatedCurl });
-    },
-    [handleOnNewValue, isCurlWebhook, value],
-  );
-
   useEffect(() => {
     const getBuilds =
       (!editNode && isBackendUrl && !hasInitialized.current) ||
@@ -88,13 +71,6 @@ export default function WebhookFieldComponent({
             {...baseInputProps}
             nodeInformationMetadata={nodeInformationMetadata}
           />
-          {!editNode && (
-            <div className="mt-2 flex items-center">
-              <WebhookCurlApiKeyButton
-                onApiKeyGenerated={handleApiKeyGenerated}
-              />
-            </div>
-          )}
         </div>
       )}
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { AuthContext } from "@/contexts/authContext";
 import { useGetBuildsMutation } from "@/controllers/API/queries/_builds/use-get-builds-polling-mutation";
 import SecretKeyModalButton from "@/customization/components/custom-secret-key-modal-button";
@@ -7,6 +7,8 @@ import { getModalPropsApiKey } from "@/customization/utils/get-modal-props";
 import type { InputProps, TextAreaComponentType } from "../../types";
 import CopyFieldAreaComponent from "../copyFieldAreaComponent";
 import TextAreaComponent from "../textAreaComponent";
+import WebhookCurlApiKeyButton from "./components/webhook-curl-api-key-button";
+import { ensureCurlHasApiKeyHeader } from "./utils/webhook-curl-utils";
 
 export default function WebhookFieldComponent({
   value,
@@ -28,6 +30,20 @@ export default function WebhookFieldComponent({
   const showGenerateToken =
     (isBackendUrl && !editNode && !isAuth) ||
     (ENABLE_DATASTAX_LANGFLOW && !editNode);
+  const handleApiKeyGenerated = useCallback(
+    (apiKeyValue: string) => {
+      if (!isCurlWebhook) {
+        return;
+      }
+
+      const updatedCurl = ensureCurlHasApiKeyHeader(
+        value ?? "",
+        apiKeyValue,
+      );
+      handleOnNewValue({ value: updatedCurl });
+    },
+    [handleOnNewValue, isCurlWebhook, value],
+  );
 
   useEffect(() => {
     const getBuilds =
@@ -72,6 +88,13 @@ export default function WebhookFieldComponent({
             {...baseInputProps}
             nodeInformationMetadata={nodeInformationMetadata}
           />
+          {!editNode && (
+            <div className="mt-2 flex items-center">
+              <WebhookCurlApiKeyButton
+                onApiKeyGenerated={handleApiKeyGenerated}
+              />
+            </div>
+          )}
         </div>
       )}
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/utils/webhook-curl-utils.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/utils/webhook-curl-utils.ts
@@ -1,0 +1,51 @@
+export const WEBHOOK_API_KEY_PLACEHOLDER = "LANGFLOW_API_KEY";
+
+const API_KEY_HEADER_REGEX = /x-api-key:\s*([^'"]+)/i;
+
+const buildApiKeyHeader = (apiKeyValue: string) =>
+  `-H "x-api-key: ${apiKeyValue}"`;
+
+export const ensureCurlHasApiKeyHeader = (
+  curlCommand: string,
+  apiKeyValue: string = WEBHOOK_API_KEY_PLACEHOLDER,
+): string => {
+  if (!curlCommand) {
+    return curlCommand;
+  }
+
+  const updatedKeyHeader = `x-api-key: ${apiKeyValue}`;
+
+  if (curlCommand.includes("x-api-key:")) {
+    return curlCommand.replace(API_KEY_HEADER_REGEX, updatedKeyHeader);
+  }
+
+  const hasNewlines = curlCommand.includes("\n");
+  const headerToken = hasNewlines
+    ? `\n  ${buildApiKeyHeader(apiKeyValue)} \\`
+    : ` ${buildApiKeyHeader(apiKeyValue)}`;
+
+  const contentTypeHeader = "-H 'Content-Type: application/json'";
+  if (hasNewlines) {
+    const contentTypeHeaderWithSlash = `${contentTypeHeader} \\`;
+    if (curlCommand.includes(contentTypeHeaderWithSlash)) {
+      return curlCommand.replace(
+        contentTypeHeaderWithSlash,
+        `${contentTypeHeaderWithSlash}\n  ${buildApiKeyHeader(apiKeyValue)} \\`,
+      );
+    }
+  }
+
+  if (curlCommand.includes(contentTypeHeader)) {
+    return curlCommand.replace(
+      contentTypeHeader,
+      `${contentTypeHeader}${headerToken}`,
+    );
+  }
+
+  const dataFlagMatch = /\s(-d\s|--data\s)/;
+  if (dataFlagMatch.test(curlCommand)) {
+    return curlCommand.replace(dataFlagMatch, `${headerToken} $1`);
+  }
+
+  return `${curlCommand}${headerToken}`.trim();
+};

--- a/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/utils/webhook-curl-utils.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/utils/webhook-curl-utils.ts
@@ -5,6 +5,24 @@ const API_KEY_HEADER_REGEX = /x-api-key:\s*([^'"]+)/i;
 const buildApiKeyHeader = (apiKeyValue: string) =>
   `-H "x-api-key: ${apiKeyValue}"`;
 
+export const getApiKeyFromCurl = (curlCommand: string): string | null => {
+  if (!curlCommand) {
+    return null;
+  }
+
+  const match = curlCommand.match(API_KEY_HEADER_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const apiKeyValue = match[1]?.trim();
+  if (!apiKeyValue || apiKeyValue === WEBHOOK_API_KEY_PLACEHOLDER) {
+    return null;
+  }
+
+  return apiKeyValue;
+};
+
 export const ensureCurlHasApiKeyHeader = (
   curlCommand: string,
   apiKeyValue: string = WEBHOOK_API_KEY_PLACEHOLDER,

--- a/src/frontend/src/modals/textAreaModal/index.tsx
+++ b/src/frontend/src/modals/textAreaModal/index.tsx
@@ -20,6 +20,7 @@ export default function ComponentTextModal({
   password,
   changeVisibility,
   onCloseModal,
+  footerSlot,
 }: textModalPropsType): JSX.Element {
   const [modalOpen, setModalOpen] = useState(false);
   const [inputValue, setInputValue] = useState(value);
@@ -94,7 +95,8 @@ export default function ComponentTextModal({
         </div>
       </BaseModal.Content>
       <BaseModal.Footer>
-        <div className="flex w-full shrink-0 items-end justify-end">
+        <div className="flex w-full shrink-0 items-center justify-between gap-3">
+          <div>{footerSlot}</div>
           <Button
             data-testid="genericModalBtnSave"
             id="genericModalBtnSave"

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -692,6 +692,7 @@ export type textModalPropsType = {
   open?: boolean;
   setOpen?: (open: boolean) => void;
   onCloseModal?: () => void;
+  footerSlot?: ReactNode;
 };
 
 export interface ToolsModalProps {


### PR DESCRIPTION
### Motivation
- Customers need the `x-api-key` header included in webhook cURL snippets and want a way to generate/fill API keys directly from the cURL UI, mirroring the API Keys screen behavior.
- The UI should assume cURL uses API keys auth for webhook snippets and provide a one-click generator that injects the key into the snippet.

### Description
- Added `ensureCurlHasApiKeyHeader` and `WEBHOOK_API_KEY_PLACEHOLDER` in `webhook-curl-utils.ts` to inject or replace the `x-api-key` header for both single-line and multi-line cURL snippets.
- Added `WebhookCurlApiKeyButton` component (`webhook-curl-api-key-button.tsx`) that generates an API key via `useGenerateToken` when `ENABLE_DATASTAX_LANGFLOW` is enabled or `createApiKey` otherwise, and returns the key via `onApiKeyGenerated`.
- Wired the generate button into the webhook UI by updating `webhookFieldComponent/index.tsx` to show the `WebhookCurlApiKeyButton` for curl fields (non-edit mode) and to update the curl value using `ensureCurlHasApiKeyHeader` when a key is generated.
- Ensured curl snippet generation in `textAreaComponent/index.tsx` runs through `ensureCurlHasApiKeyHeader` so generated single-line and multiline webhook snippets include the `x-api-key` header placeholder.

### Testing
- Started the frontend dev server with `npm --prefix src/frontend run dev:docker`, which launched Vite successfully and served the app at `http://localhost:3000/` (success).
- Ran a Playwright script that opened the app and captured a screenshot of the webhook cURL UI, producing artifact `artifacts/webhook-curl-api-key.png` (success).
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69896ac06e08832698417c5f54e3e7d1)