### PR TITLE
Route Pricing CTA via organization selection and add pricing bypass to ProtectedRoute

### DIFF
--- a/src/frontend/src/components/authorization/authGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authGuard/index.tsx
@@ -1,25 +1,25 @@
+import { useAuth as useClerkAuth, useOrganization } from "@clerk/clerk-react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import {
   IS_AUTO_LOGIN,
   LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS,
   LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV,
 } from "@/constants/constants";
 import { api } from "@/controllers/API/api";
+import { getURL } from "@/controllers/API/helpers/constants";
 import { useRefreshAccessToken } from "@/controllers/API/queries/auth";
 import { CustomNavigate } from "@/customization/components/custom-navigate";
 import useAuthStore from "@/stores/authStore";
-import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
-import { useOrganization, useAuth as useClerkAuth } from "@clerk/clerk-react";
-import { getURL } from "@/controllers/API/helpers/constants";
 
 export const ProtectedRoute = ({ children }) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const autoLogin = useAuthStore((state) => state.autoLogin);
   const isOrgSelectedStore = useAuthStore((state) => state.isOrgSelected);
-  
+
   const { mutate: mutateRefresh } = useRefreshAccessToken();
   const testMockAutoLogin = sessionStorage.getItem("testMockAutoLogin");
-  
+
   // Clerk values
   const { organization, isLoaded: isOrgLoaded } = useOrganization();
   const isOrgSelected =
@@ -31,12 +31,16 @@ export const ProtectedRoute = ({ children }) => {
   // Get current path
   const location = useLocation();
   const currentPath = location.pathname;
+  const currentSearch = location.search;
   const isLoginPage = currentPath.includes("login");
   const isOrgPage = currentPath.includes("organization");
   const isAdminPage = currentPath.includes("/admin");
   const isRootPage = currentPath === "/";
   const isFlowsPage = currentPath.includes("/flows");
   const isPricingPage = currentPath.includes("/pricing");
+  const isPricingBypass =
+    isFlowsPage &&
+    new URLSearchParams(currentSearch).get("pricing_bypass") === "1";
 
   // 🔹 Billing state
   const [hasAccess, setHasAccess] = useState<boolean | null>(null);
@@ -44,7 +48,7 @@ export const ProtectedRoute = ({ children }) => {
 
   // 🔹 Billing check for /flows
   useEffect(() => {
-    if (!isFlowsPage) return;
+    if (!isFlowsPage || isPricingBypass) return;
     if (!isOrgLoaded || !isClerkLoaded || !isSignedIn || !isOrgSelected) return;
 
     let active = true;
@@ -74,7 +78,15 @@ export const ProtectedRoute = ({ children }) => {
     return () => {
       active = false;
     };
-    }, [isFlowsPage, isOrgLoaded, isClerkLoaded, isSignedIn, isOrgSelected, getToken]);
+  }, [
+    isFlowsPage,
+    isPricingBypass,
+    isOrgLoaded,
+    isClerkLoaded,
+    isSignedIn,
+    isOrgSelected,
+    getToken,
+  ]);
 
   // 🔄 Setup token refresh
   useEffect(() => {
@@ -125,7 +137,9 @@ export const ProtectedRoute = ({ children }) => {
       return <CustomNavigate to="/organization" replace />;
     }
 
-    if (isSignedIn && hasAccess === null) {
+    if (isPricingBypass) {
+      // Temporary bypass from pricing placeholder until checkout is implemented
+    } else if (isSignedIn && hasAccess === null) {
       return null;
     }
 
@@ -133,7 +147,7 @@ export const ProtectedRoute = ({ children }) => {
       return null;
     }
 
-    if (hasAccess === false) {
+    if (!isPricingBypass && hasAccess === false) {
       return <CustomNavigate to="/pricing" replace />;
     }
   }

--- a/src/frontend/src/pages/PricingPage/index.tsx
+++ b/src/frontend/src/pages/PricingPage/index.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 
 export default function PricingPage() {
   const navigate = useNavigate();
+  const pricingBypassRedirect = encodeURIComponent("/flows?pricing_bypass=1");
 
   return (
     <div
@@ -24,13 +25,39 @@ export default function PricingPage() {
           padding: "1.25rem",
         }}
       >
-        <h1 style={{ marginTop: 0, fontSize: "1.75rem" }}>Pricing (Placeholder)</h1>
+        <h1 style={{ marginTop: 0, fontSize: "1.75rem" }}>
+          Pricing (Placeholder)
+        </h1>
         <p style={{ opacity: 0.85, lineHeight: 1.6 }}>
-          Your organization requires billing setup before entering flows. This is a temporary
-          pricing page placeholder. Final Clerk + Paddle checkout UI will replace this soon.
+          Your organization requires billing setup before entering flows. This
+          is a temporary pricing page placeholder. Final Clerk + Paddle checkout
+          UI will replace this soon.
         </p>
 
-        <div style={{ display: "flex", gap: ".75rem", flexWrap: "wrap", marginTop: "1rem" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: ".75rem",
+            flexWrap: "wrap",
+            marginTop: "1rem",
+          }}
+        >
+          <button
+            type="button"
+            onClick={() =>
+              navigate(`/organization?redirect=${pricingBypassRedirect}`)
+            }
+            style={{
+              padding: ".65rem 1rem",
+              borderRadius: "10px",
+              border: "1px solid rgba(74,222,128,.5)",
+              background: "rgba(20,83,45,.8)",
+              color: "#bbf7d0",
+              cursor: "pointer",
+            }}
+          >
+            Continue to flows (temporary)
+          </button>
           <button
             type="button"
             onClick={() => navigate("/organization")}


### PR DESCRIPTION
### Motivation
- The temporary Pricing CTA attempted to go directly to `/flows`, but the `ProtectedRoute` billing check and organization-selection logic could block or redirect users without an active org and create navigation loops. 
- Provide a short-lived, controlled bypass so the placeholder Pricing page can reach Flows while requiring users to complete organization selection first.

### Description
- Update `src/frontend/src/pages/PricingPage/index.tsx` to encode the target `/flows?pricing_bypass=1` and navigate to `/organization?redirect=%2Fflows%3Fpricing_bypass%3D1` when the user clicks the temporary CTA so org selection completes before entering flows. 
- Update `src/frontend/src/components/authorization/authGuard/index.tsx` to read `location.search`, expose an `isPricingBypass` flag when `pricing_bypass=1` is present, add it to effect dependencies, skip the billing access API check for bypassed requests, and avoid redirecting bypassed requests back to `/pricing` while preserving normal auth and org checks. 
- Small import and formatting adjustments in `authGuard/index.tsx` to support the new logic.

### Testing
- Ran `npm --prefix src/frontend run format src/pages/PricingPage/index.tsx` which completed successfully. 
- Ran `npm --prefix src/frontend run check-format src/pages/PricingPage/index.tsx` which completed successfully. 
- Previously ran `npm --prefix src/frontend run format src/components/authorization/authGuard/index.tsx src/pages/PricingPage/index.tsx` and `npm --prefix src/frontend run check-format src/components/authorization/authGuard/index.tsx src/pages/PricingPage/index.tsx`; formatting passed and checking passed but an existing `noConsole` lint warning in the auth guard file was reported (pre-existing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e4a4fc74832688cf7b10713cc7c8)