### PR TITLE
Externalize plan config, dynamic Paddle provisioning, and frontend price caching

### DIFF
--- a/src/backend/base/langflow/services/paddle/provisioning.py
+++ b/src/backend/base/langflow/services/paddle/provisioning.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from langflow.services.paddle.subscriptions import _normalize_custom_data
@@ -28,20 +31,28 @@ class PlanDefinition:
     trial_days: int | None = None
 
 
-PLANS: tuple[PlanDefinition, ...] = (
-    PlanDefinition(
-        key="starter_pack_monthly",
-        name="Starter",
-        monthly_price_usd="2000",
-        trial_days=7,
-    ),
-    PlanDefinition(
-        key="pro_pack_monthly",
-        name="Pro",
-        monthly_price_usd="5000",
-        trial_days=None,
-    ),
-)
+@lru_cache(maxsize=1)
+def _load_plan_config() -> dict[str, Any]:
+    config_path = Path(__file__).resolve().parents[5] / "common" / "plan_config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        return json.load(config_file)
+
+
+def _get_paddle_plans() -> tuple[PlanDefinition, ...]:
+    plans = []
+    for plan in _load_plan_config().get("plans", []):
+        paddle = plan.get("paddle", {})
+        if not paddle.get("enabled"):
+            continue
+        plans.append(
+            PlanDefinition(
+                key=str(paddle["plan_key"]),
+                name=str(plan["name"]).replace(" Pack", ""),
+                monthly_price_usd=str(paddle["monthly_price_usd_cents"]),
+                trial_days=paddle.get("trial_days"),
+            )
+        )
+    return tuple(plans)
 
 
 def provision_paddle_plans() -> None:
@@ -57,7 +68,7 @@ def provision_paddle_plans() -> None:
     products = list(client.products.list())
     prices = list(client.prices.list())
 
-    for plan in PLANS:
+    for plan in _get_paddle_plans():
         product = _find_existing_product(plan, products)
         if _find_existing_price(plan, prices, product):
             logger.info("Paddle plan %s already provisioned; skipping.", plan.key)

--- a/src/backend/base/langflow/services/paddle/provisioning.py
+++ b/src/backend/base/langflow/services/paddle/provisioning.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -21,6 +22,12 @@ from paddle_billing.Entities.Shared.TaxCategory import TaxCategory
 from paddle_billing.Entities.Shared.TaxMode import TaxMode
 from paddle_billing.Resources.Prices.Operations import CreatePrice
 from paddle_billing.Resources.Products.Operations import CreateProduct
+
+
+
+PRICE_MAP_CACHE_TTL_SECONDS = 60 * 60
+_cached_price_map: dict[str, str] | None = None
+_cached_price_map_expires_at = 0.0
 
 
 @dataclass(frozen=True)
@@ -204,6 +211,10 @@ async def get_paddle_prices(
     *,
     client: Client | None = None,
 ) -> dict[str, str]:
+    global _cached_price_map, _cached_price_map_expires_at
+
+    if client is None and _cached_price_map and time.time() < _cached_price_map_expires_at:
+        return _cached_price_map
 
     paddle_client = client or get_paddle_client()
 
@@ -231,5 +242,9 @@ async def get_paddle_prices(
         raise ValueError(
             "No Paddle price IDs found — make sure plans are provisioned"
         )
+
+    if client is None:
+        _cached_price_map = price_map
+        _cached_price_map_expires_at = time.time() + PRICE_MAP_CACHE_TTL_SECONDS
 
     return price_map

--- a/src/common/plan_config.json
+++ b/src/common/plan_config.json
@@ -1,0 +1,55 @@
+{
+  "plans": [
+    {
+      "key": "starter",
+      "name": "Starter Pack",
+      "paddle": {
+        "enabled": true,
+        "plan_key": "starter_pack_monthly",
+        "monthly_price_usd_cents": 2000,
+        "trial_days": 7
+      },
+      "default_seats": 1,
+      "features": [
+        "Shared database",
+        "Standard rate limits",
+        "Core visual builder features",
+        "Community support"
+      ]
+    },
+    {
+      "key": "pro",
+      "name": "Pro Pack",
+      "paddle": {
+        "enabled": true,
+        "plan_key": "pro_pack_monthly",
+        "monthly_price_usd_cents": 5000,
+        "trial_days": null
+      },
+      "default_seats": 1,
+      "features": [
+        "Separate database",
+        "Highly enabled rate limits",
+        "Team collaboration tools",
+        "Priority email support"
+      ]
+    },
+    {
+      "key": "enterprise",
+      "name": "Enterprise Pack",
+      "paddle": {
+        "enabled": false,
+        "plan_key": "enterprise_pack_monthly",
+        "monthly_price_usd_cents": 12000,
+        "trial_days": null
+      },
+      "default_seats": 5,
+      "features": [
+        "Dedicated environments",
+        "Custom security & compliance",
+        "SSO and role-based access",
+        "Premium SLA & support"
+      ]
+    }
+  ]
+}

--- a/src/frontend/src/pages/PricingPage/index.tsx
+++ b/src/frontend/src/pages/PricingPage/index.tsx
@@ -4,19 +4,59 @@ import type { SVGProps } from "react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getURL } from "../../controllers/API/helpers/constants";
+import planConfigData from "../../../../common/plan_config.json";
 
 const MIN_SEATS = 1;
+const PADDLE_PRICE_CACHE_KEY = "pricing_page_paddle_prices";
+const PADDLE_PRICE_CACHE_TTL_MS = 60 * 60 * 1000;
 
 type PlanKey = "starter" | "pro" | "enterprise";
 
-const PLAN_KEY_MAP: Record<
-  PlanKey,
-  "starter_pack_monthly" | "pro_pack_monthly" | "enterprise_pack_monthly"
-> = {
-  starter: "starter_pack_monthly",
-  pro: "pro_pack_monthly",
-  enterprise: "enterprise_pack_monthly",
-};
+interface SharedPlanConfig {
+  key: PlanKey;
+  name: string;
+  default_seats: number;
+  features: string[];
+  paddle: {
+    enabled: boolean;
+    plan_key: "starter_pack_monthly" | "pro_pack_monthly" | "enterprise_pack_monthly";
+    monthly_price_usd_cents: number;
+    trial_days: number | null;
+  };
+}
+
+interface CachedPriceMap {
+  fetchedAt: number;
+  prices: Record<string, string>;
+}
+
+function getCachedPriceMap(): Record<string, string> | null {
+  try {
+    const raw = window.localStorage.getItem(PADDLE_PRICE_CACHE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as CachedPriceMap;
+    const isExpired = Date.now() - parsed.fetchedAt > PADDLE_PRICE_CACHE_TTL_MS;
+
+    if (isExpired) {
+      window.localStorage.removeItem(PADDLE_PRICE_CACHE_KEY);
+      return null;
+    }
+
+    return parsed.prices ?? null;
+  } catch {
+    window.localStorage.removeItem(PADDLE_PRICE_CACHE_KEY);
+    return null;
+  }
+}
+
+function setCachedPriceMap(prices: Record<string, string>): void {
+  const payload: CachedPriceMap = {
+    fetchedAt: Date.now(),
+    prices,
+  };
+  window.localStorage.setItem(PADDLE_PRICE_CACHE_KEY, JSON.stringify(payload));
+}
 
 interface PlanConfig {
   key: PlanKey;
@@ -25,47 +65,20 @@ interface PlanConfig {
   hasTrial: boolean;
   trialDays?: number;
   features: string[];
+  paddlePlanKey: "starter_pack_monthly" | "pro_pack_monthly" | "enterprise_pack_monthly";
+  defaultSeats: number;
 }
 
-const STATIC_PLANS: PlanConfig[] = [
-  {
-    key: "starter",
-    name: "Starter Pack",
-    pricePerSeat: 20,
-    hasTrial: true,
-    trialDays: 7,
-    features: [
-      "Shared database",
-      "Standard rate limits",
-      "Core visual builder features",
-      "Community support",
-    ],
-  },
-  {
-    key: "pro",
-    name: "Pro Pack",
-    pricePerSeat: 50,
-    hasTrial: false,
-    features: [
-      "Separate database",
-      "Highly enabled rate limits",
-      "Team collaboration tools",
-      "Priority email support",
-    ],
-  },
-  {
-    key: "enterprise",
-    name: "Enterprise Pack",
-    pricePerSeat: 120,
-    hasTrial: false,
-    features: [
-      "Dedicated environments",
-      "Custom security & compliance",
-      "SSO and role-based access",
-      "Premium SLA & support",
-    ],
-  },
-];
+const STATIC_PLANS: PlanConfig[] = (planConfigData.plans as SharedPlanConfig[]).map((plan) => ({
+  key: plan.key,
+  name: plan.name,
+  pricePerSeat: plan.paddle.monthly_price_usd_cents / 100,
+  hasTrial: plan.paddle.trial_days !== null,
+  trialDays: plan.paddle.trial_days ?? undefined,
+  features: plan.features,
+  paddlePlanKey: plan.paddle.plan_key,
+  defaultSeats: plan.default_seats,
+}));
 
 function CheckIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -87,9 +100,10 @@ export default function PricingPage() {
 
   const [selectedPlan, setSelectedPlan] = useState<PlanKey>("starter");
   const [seatsByPlan, setSeatsByPlan] = useState<Record<PlanKey, number>>({
-    starter: 1,
-    pro: 1,
-    enterprise: 5,
+    starter: STATIC_PLANS.find((plan) => plan.key === "starter")?.defaultSeats ?? 1,
+    pro: STATIC_PLANS.find((plan) => plan.key === "pro")?.defaultSeats ?? 1,
+    enterprise:
+      STATIC_PLANS.find((plan) => plan.key === "enterprise")?.defaultSeats ?? 5,
   });
 
   const [priceMap, setPriceMap] = useState<Record<string, string>>({});
@@ -97,9 +111,18 @@ export default function PricingPage() {
 
   useEffect(() => {
     const fetchPrices = async () => {
+      const cachedPrices = getCachedPriceMap();
+      if (cachedPrices) {
+        setPriceMap(cachedPrices);
+        setLoadingPrices(false);
+        return;
+      }
+
       try {
         const { data } = await axios.get(getURL("GET_PADDLE_PRICES"));
-        setPriceMap(data ?? {});
+        const freshPrices = data ?? {};
+        setPriceMap(freshPrices);
+        setCachedPriceMap(freshPrices);
       } catch (err) {
         console.error("Failed to load Paddle price IDs:", err);
       } finally {
@@ -139,7 +162,7 @@ export default function PricingPage() {
       return;
     }
 
-    const planKey = PLAN_KEY_MAP[plan.key];
+    const planKey = plan.paddlePlanKey;
     const priceId = priceMap[planKey];
 
     if (!priceId) {


### PR DESCRIPTION
### Motivation
- Move plan definitions out of code into a single JSON file so plans can be edited without code changes. 
- Make backend Paddle provisioning read the external config to provision only enabled plans. 
- Improve frontend pricing UX by deriving plan metadata from the shared config and caching Paddle price IDs to reduce network calls.

### Description
- Add `src/common/plan_config.json` to centralize plan metadata and Paddle settings. 
- Replace hard-coded `PlanDefinition` tuple with `_load_plan_config()` and `_get_paddle_plans()` in `provisioning.py`, using `@lru_cache` and JSON parsing to load plan config. 
- Update `provision_paddle_plans()` to iterate over plans from `_get_paddle_plans()` and skip disabled plans. 
- Import `plan_config.json` into the frontend `PricingPage` and map it to `STATIC_PLANS`, adding typed interfaces and using config values for `pricePerSeat`, `trialDays`, `defaultSeats`, and `paddlePlanKey`. 
- Add localStorage caching for Paddle price IDs on the frontend with a TTL (`PADDLE_PRICE_CACHE_KEY` and `PADDLE_PRICE_CACHE_TTL_MS`) and helper functions `getCachedPriceMap()` and `setCachedPriceMap()`. 
- Replace previous static plan key map with values read from the shared config and use cached/fresh Paddle price IDs when opening the Paddle checkout.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae86bde80c83268a3f3ab484660ac8)