### PR TITLE
Refactor Paddle checkout handling to fetch subscription using Clerk token

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,14 +1,51 @@
-import { Suspense, useEffect } from "react";
+import { useAuth } from "@clerk/clerk-react";
+import { initializePaddle } from "@paddle/paddle-js";
+import { Suspense, useCallback, useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
+import { IS_CLERK_AUTH } from "@/clerk/auth";
+import api from "@/controllers/API/api";
+import { getURL } from "@/controllers/API/helpers/constants";
 import { LoadingPage } from "./pages/LoadingPage";
 import router from "./routes";
 import { useDarkStore } from "./stores/darkStore";
-import { initializePaddle } from "@paddle/paddle-js";
 
-const PADDLE_ENVIRONMENT = (import.meta.env.VITE_PADDLE_ENVIRONMENT)=="staging" ? "sandbox" : "production";
+const PADDLE_ENVIRONMENT =
+  import.meta.env.VITE_PADDLE_ENVIRONMENT === "staging"
+    ? "sandbox"
+    : "production";
 const PADDLE_TOKEN = import.meta.env.VITE_PADDLE_CLIENT_KEY;
+
 export default function App() {
   const dark = useDarkStore((state) => state.dark);
+  const { getToken } = IS_CLERK_AUTH
+    ? useAuth()
+    : { getToken: async () => null };
+
+  const fetchPaddleSubscription = useCallback(async () => {
+    if (!IS_CLERK_AUTH) {
+      console.warn("Skipping Paddle subscription lookup because Clerk auth is disabled");
+      return;
+    }
+
+    try {
+      const clerkToken = await getToken();
+
+      if (!clerkToken) {
+        console.warn("Unable to resolve Clerk token for Paddle subscription lookup");
+        return;
+      }
+
+      const { data } = await api.get(getURL("BILLING_ACCESS"), {
+        headers: {
+          Authorization: `Bearer ${clerkToken}`,
+        },
+      });
+
+      console.log("Resolved Paddle subscription from backend:", data);
+    } catch (error) {
+      console.error("Failed to fetch Paddle subscription from backend", error);
+    }
+  }, [getToken]);
 
   // Dark mode + dynamic css import
   useEffect(() => {
@@ -21,32 +58,31 @@ export default function App() {
   }, [dark]);
 
   useEffect(() => {
-  initializePaddle({
-    environment: PADDLE_ENVIRONMENT,
-    token: PADDLE_TOKEN,
-    eventCallback: (event) => {
-      console.log("Paddle event:", event);
+    initializePaddle({
+      environment: PADDLE_ENVIRONMENT,
+      token: PADDLE_TOKEN,
+      eventCallback: (event) => {
+        console.log("Paddle event:", event);
 
-      // Checkout completed
-      if (event.name === "checkout.completed") {
-        const subscriptionId = (event.data as any)?.subscription?.id;
-        console.log("Subscription ID:", subscriptionId);
-         // navigate on success
-      }
+        if (event.name === "checkout.completed") {
+          const customerId = (event.data as any)?.customer?.id;
+          const subscriptionId = (event.data as any)?.subscription?.id;
 
-      // Checkout closed
-      if (event.name === "checkout.closed") {
-        console.log("Checkout closed");
-      }
-    },
-    checkout: {
-      // you can set global default settings here
-      settings: {
-        allowLogout: false,
+          console.log("Paddle checkout completed", { customerId, subscriptionId });
+          void fetchPaddleSubscription();
+        }
+
+        if (event.name === "checkout.closed") {
+          console.log("Checkout closed");
+        }
       },
-    },
-  });
-}, []);
+      checkout: {
+        settings: {
+          allowLogout: false,
+        },
+      },
+    });
+  }, [fetchPaddleSubscription]);
 
   return (
     <Suspense fallback={<LoadingPage />}>


### PR DESCRIPTION
### Motivation
- Decouple backend subscription lookup from Paddle client initialization so the app can retrieve subscription state using Clerk authentication instead of embedding token logic in `initializePaddle`.
- Ensure the billing access call is performed with a valid Clerk bearer token so the backend can resolve Paddle subscription data from Clerk metadata.

### Description
- Updated `src/frontend/src/App.tsx` to import `useAuth`, `IS_CLERK_AUTH`, `api`, and `getURL` and removed subscription logic from the inline Paddle init.
- Added a `fetchPaddleSubscription` `useCallback` that calls `getToken()` and requests `getURL("BILLING_ACCESS")` with `Authorization: Bearer <clerkToken>` to resolve subscription state.
- Kept `initializePaddle` for client setup and modified its `eventCallback` so `checkout.completed` now invokes `fetchPaddleSubscription()` (instead of performing subscription fetch inline).
- Preserved existing Paddle settings (e.g., `allowLogout: false`) and added `fetchPaddleSubscription` to the `useEffect` dependency array to ensure stable references.

### Testing
- Ran `git diff --check` which produced no check errors (success).
- Ran `npx @biomejs/biome check src/frontend/src/App.tsx` which failed due to nested Biome configuration in the repository (configuration error).
- Ran `npx tsc --noEmit --project src/frontend/tsconfig.json` which timed out in this environment before completing (did not finish).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c123db3c6083268b885347b720d692)