### PR TITLE
Fix nginx proxying for /new/landingpage API routes (restores MCP/backend connectivity)

### DIFF
--- a/docker/frontend/default.conf.template
+++ b/docker/frontend/default.conf.template
@@ -39,10 +39,25 @@ http {
 
         location /api {
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
+        }
+        location = /new/landingpage/api {
+            return 307 /new/landingpage/api/;
         }
         location /new/landingpage/api/ {
             rewrite ^/new/landingpage/(.*)$ /$1 break;
             proxy_pass ${BACKEND_URL};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
         }
         location /health_check {
             proxy_pass ${BACKEND_URL};

--- a/docker/frontend/default.conf.template
+++ b/docker/frontend/default.conf.template
@@ -40,6 +40,10 @@ http {
         location /api {
             proxy_pass ${BACKEND_URL};
         }
+        location /new/landingpage/api/ {
+            rewrite ^/new/landingpage/(.*)$ /$1 break;
+            proxy_pass ${BACKEND_URL};
+        }
         location /health_check {
             proxy_pass ${BACKEND_URL};
         }

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -19,6 +19,10 @@ server {
     location /api {
         proxy_pass __BACKEND_URL__;
     }
+    location /new/landingpage/api/ {
+        rewrite ^/new/landingpage/(.*)$ /$1 break;
+        proxy_pass __BACKEND_URL__;
+    }
     location /health_check {
         proxy_pass __BACKEND_URL__;
     }

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -18,10 +18,25 @@ server {
     }
     location /api {
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+    location = /new/landingpage/api {
+        return 307 /new/landingpage/api/;
     }
     location /new/landingpage/api/ {
         rewrite ^/new/landingpage/(.*)$ /$1 break;
         proxy_pass __BACKEND_URL__;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
     }
     location /health_check {
         proxy_pass __BACKEND_URL__;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -46,6 +46,20 @@ http {
             try_files $uri $uri/ /new/landingpage/index.html;
         }
 
+        # Proxy API requests initiated from the landing page when clients
+        # resolve relative URLs against the /new/landingpage/ base path.
+        location ^~ /new/landingpage/api/ {
+            rewrite ^/new/landingpage/(.*)$ /$1 break;
+            proxy_pass http://127.0.0.1:${LANGFLOW_BACKEND_PORT};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
         location = /new/landingpage/index.html {
             alias /app/new-landingpage/dist/index.html;
         }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -48,6 +48,10 @@ http {
 
         # Proxy API requests initiated from the landing page when clients
         # resolve relative URLs against the /new/landingpage/ base path.
+        location = /new/landingpage/api {
+            return 307 /new/landingpage/api/;
+        }
+
         location ^~ /new/landingpage/api/ {
             rewrite ^/new/landingpage/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:${LANGFLOW_BACKEND_PORT};
@@ -58,6 +62,9 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
         }
 
         location = /new/landingpage/index.html {


### PR DESCRIPTION
### Motivation
- After adding the new landing page under `src/new-landingpage`, client-side API calls resolved to `/new/landingpage/api/...` and were captured by the SPA/static routing, which prevented backend-dependent features such as MCP connections from reaching the server.

### Description
- Add an explicit Nginx `location` for `/new/landingpage/api/` that rewrites `^/new/landingpage/(.*)$` to `/$1` and proxies the request to the backend while preserving websocket/SSE headers in `docker/nginx/nginx.conf`.
- Apply the same proxy+rewrite rule to the frontend Nginx template `docker/frontend/default.conf.template` so packaged deployments route correctly.
- Apply the same rule to the runtime frontend config `docker/frontend/nginx.conf` so local/frontend container behavior matches deployment.
- The rewrite removes the `/new/landingpage/` prefix so backend endpoints (for example `/api/v1/...`) receive the expected paths.

### Testing
- Ran `rg -n "new/landingpage/api"` across the three modified configs to confirm the location blocks are present and found the new rules (succeeded).
- Inspected the modified files with `nl -ba ... | sed -n ...` to verify the inserted proxy/rewrite blocks and websocket headers (succeeded).
- Applied patches with the automated `apply_patch` tool which returned success for all three files (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c584dbbc8326b415d37c8e56018e)